### PR TITLE
Small code refactors

### DIFF
--- a/samples/NetArchTest.SampleLibrary/Data/WidgetRepository.cs
+++ b/samples/NetArchTest.SampleLibrary/Data/WidgetRepository.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NetArchTest.SampleLibrary.Model;
+    using Model;
 
     public class WidgetRepository : IRepository<Widget>, IDisposable
     {

--- a/samples/NetArchTest.SampleLibrary/Presentation/WidgetController.cs
+++ b/samples/NetArchTest.SampleLibrary/Presentation/WidgetController.cs
@@ -2,7 +2,7 @@
 {
     using System.Linq;
     using System.Threading.Tasks;
-    using NetArchTest.SampleLibrary.Services;
+    using Services;
 
     public class WidgetController
     {

--- a/samples/NetArchTest.SampleLibrary/Services/IWidgetService.cs
+++ b/samples/NetArchTest.SampleLibrary/Services/IWidgetService.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NetArchTest.SampleLibrary.Model;
+    using Model;
 
     public interface IWidgetService 
     {

--- a/samples/NetArchTest.SampleLibrary/Services/WidgetService.cs
+++ b/samples/NetArchTest.SampleLibrary/Services/WidgetService.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.SampleLibrary.Services
 {
-    using NetArchTest.SampleLibrary.Data;
-    using NetArchTest.SampleLibrary.Model;
+    using Data;
+    using Model;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 

--- a/samples/NetArchTest.SampleRules/CustomRule.cs
+++ b/samples/NetArchTest.SampleRules/CustomRule.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.SampleRules
 {
     using Mono.Cecil;
-    using NetArchTest.Rules;
+    using Rules;
 
     /// <summary>
     /// A custom rule that can be used to extend NetArchTest.

--- a/samples/NetArchTest.SampleRules/ExamplePolicies.cs
+++ b/samples/NetArchTest.SampleRules/ExamplePolicies.cs
@@ -4,10 +4,10 @@
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
-    using NetArchTest.Rules;
-    using NetArchTest.Policies;
-    using NetArchTest.SampleLibrary.Data;
-    using NetArchTest.SampleLibrary.Services;
+    using Rules;
+    using Policies;
+    using SampleLibrary.Data;
+    using SampleLibrary.Services;
 
     /// <summary>
     /// Examples of how rules can be aggregated into policies that are executed in a group.

--- a/samples/NetArchTest.SampleRules/ExampleRules.cs
+++ b/samples/NetArchTest.SampleRules/ExampleRules.cs
@@ -1,8 +1,8 @@
 ﻿namespace NetArchTest.SampleRules
 {
-    using NetArchTest.Rules;
-    using NetArchTest.SampleLibrary.Data;
-    using NetArchTest.SampleLibrary.Services;
+    using Rules;
+    using SampleLibrary.Data;
+    using SampleLibrary.Services;
 
     /// <summary>
     /// Examples of rule definitions.

--- a/samples/SampleApp.API/Controllers/WeatherForecastController.cs
+++ b/samples/SampleApp.API/Controllers/WeatherForecastController.cs
@@ -6,10 +6,10 @@ namespace SampleApp.API.Controllers
     [Route("[controller]")]
     public class WeatherForecastController : ControllerBase
     {
-        private static readonly string[] Summaries = new[]
-        {
+        private static readonly string[] Summaries =
+        [
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-        };
+        ];
 
         private readonly ILogger<WeatherForecastController> _logger;
 

--- a/sources/NetArchTest/Assemblies/AssemblySpec.cs
+++ b/sources/NetArchTest/Assemblies/AssemblySpec.cs
@@ -8,35 +8,31 @@ namespace NetArchTest.Assemblies
 {
     internal sealed class AssemblySpec
     {
-        private AssemblyDefinition assemblyDefinition;
-        private IReadOnlyList<TypeDefinition> typeDefinitions;
-        private List<AssemblySpec> referenced = new List<AssemblySpec>();
+        private readonly AssemblyDefinition _assemblyDefinition;
+        private readonly TypeDefinition[] _typeDefinitions;
+        private readonly List<AssemblySpec> _referenced = [];
 
-        public string FullName => assemblyDefinition.FullName;
-
-
+        public string FullName => _assemblyDefinition.FullName;
 
         public AssemblySpec(AssemblyDefinition assemblyDefinition, IEnumerable<TypeDefinition> typeDefinitions)
         {
-            this.assemblyDefinition = assemblyDefinition;
-            this.typeDefinitions = typeDefinitions.ToArray();
+            _assemblyDefinition = assemblyDefinition;
+            _typeDefinitions = typeDefinitions.ToArray();
         }
 
         public void AddRef(AssemblySpec assemblySpec)
         {
-            referenced.Add(assemblySpec);
+            _referenced.Add(assemblySpec);
         }
 
-        public IEnumerable<TypeSpec> GetTypes() 
+        public IEnumerable<TypeSpec> GetTypes()
         {
-            return typeDefinitions.Select(x => new TypeSpec(x));
+            return _typeDefinitions.Select(x => new TypeSpec(x));
         }
-
-
 
         public IAssembly CreateWrapper()
         {
-            return new AssemblyContainer(assemblyDefinition);
+            return new AssemblyContainer(_assemblyDefinition);
         }
     }
 }

--- a/sources/NetArchTest/Assemblies/DataLoader.cs
+++ b/sources/NetArchTest/Assemblies/DataLoader.cs
@@ -10,14 +10,14 @@ namespace NetArchTest.Assemblies
 {
     internal static class DataLoader
     {
-        private static readonly List<string> exclusionList = new List<string> 
-        { 
+        private static readonly List<string> ExclusionList =
+        [
             "System",
-            "Microsoft", 
-            "netstandard", 
-            "NuGet", 
+            "Microsoft",
+            "netstandard",
+            "NuGet",
             "Newtonsoft",
-            "xunit", 
+            "xunit",
             "Internal.Microsoft",
             "Mono.Cecil",
             "NetArchTest.Assemblies",
@@ -26,10 +26,9 @@ namespace NetArchTest.Assemblies
             "NetArchTest.Policies",
             "NetArchTest.RuleEngine",
             "NetArchTest.Rules",
-            "NetArchTest.Slices",
-        };
-        private static readonly NamespaceTree exclusionTree = new NamespaceTree(exclusionList);
-
+            "NetArchTest.Slices"
+        ];
+        private static readonly NamespaceTree ExclusionTree = new NamespaceTree(ExclusionList);
 
         public static LoadedData LoadFromCurrentDomain()
         {
@@ -51,7 +50,6 @@ namespace NetArchTest.Assemblies
             return new LoadedData(assemblies);
         }
 
-
         private static IEnumerable<AssemblySpec> Load(IEnumerable<string> fileNames, IEnumerable<string> searchDirectories, bool loadReferencedAssemblies)
         {
             var readerParameters = CreateReaderParameters(searchDirectories);
@@ -66,7 +64,7 @@ namespace NetArchTest.Assemblies
             void ProcessAssemblyDefinition(AssemblySpec parent, AssemblyDefinition assemblyDefinition)
             {
                 if (assemblyDefinition == null) return;
-                if (exclusionTree.GetAllMatchingNames(assemblyDefinition.Name.Name).Any() == true) return;
+                if (ExclusionTree.GetAllMatchingNames(assemblyDefinition.Name.Name).Any() == true) return;
                 if (definitions.TryGetValue(assemblyDefinition.FullName, out var existingSpec))
                 {
                     parent?.AddRef(existingSpec);
@@ -96,7 +94,7 @@ namespace NetArchTest.Assemblies
 
             return definitions.Values;
         }
-       
+
         private static ReaderParameters CreateReaderParameters(IEnumerable<string> searchDirectories, bool readSymbols = true)
         {
             DefaultAssemblyResolver assemblyResolver = null;
@@ -123,37 +121,33 @@ namespace NetArchTest.Assemblies
             }
         }
 
-
         private static IEnumerable<TypeDefinition> ReadTypes(AssemblyDefinition assemblyDefinition)
         {
             foreach (var module in assemblyDefinition.Modules)
             {
                 foreach (var type in module.GetTypes())
-                {                   
+                {
                     if (type.FullName.Equals("<Module>")) continue;
                     if (type.FullName.StartsWith("<>")) continue;
                     if (type.FullName.StartsWith("<PrivateImplementationDetails>")) continue;
 
-                    if (exclusionTree.GetAllMatchingNames(type.FullName).Any()) continue;
+                    if (ExclusionTree.GetAllMatchingNames(type.FullName).Any()) continue;
                     if (type.IsCompilerGenerated()) continue;
 
                     yield return type;
                 }
             }
         }
-    }       
-
+    }
 
     internal sealed class LoadedData
     {
         public IReadOnlyList<AssemblySpec> Assemblies { get; }
 
-
         public LoadedData(IEnumerable<AssemblySpec> assemblies)
         {
             Assemblies = assemblies.ToArray();
         }
-
 
         public IEnumerable<TypeSpec> GetTypes()
         {

--- a/sources/NetArchTest/Assemblies/PublicUse/AssemblyContainer.cs
+++ b/sources/NetArchTest/Assemblies/PublicUse/AssemblyContainer.cs
@@ -5,18 +5,11 @@ using NetArchTest.Rules;
 namespace NetArchTest.Assemblies.PublicUse
 {
     [DebuggerDisplay("{FullName}")]
-    internal sealed class AssemblyContainer : IAssembly
+    internal sealed class AssemblyContainer(AssemblyDefinition assemblyDefinition) : IAssembly
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly AssemblyDefinition _monoAssemblyDefinition;
-
+        private readonly AssemblyDefinition _monoAssemblyDefinition = assemblyDefinition;
 
         public string FullName => _monoAssemblyDefinition.FullName;
-
-
-        public AssemblyContainer(AssemblyDefinition assemblyDefinition)
-        {
-            _monoAssemblyDefinition = assemblyDefinition;
-        }
     }
 }

--- a/sources/NetArchTest/Assemblies/PublicUse/TypeContainer.cs
+++ b/sources/NetArchTest/Assemblies/PublicUse/TypeContainer.cs
@@ -11,22 +11,20 @@ namespace NetArchTest.Assemblies.PublicUse
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly TypeDefinition _monoTypeDefinition;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Lazy<Type> _reflactionType;
+        private readonly Lazy<Type> _reflectionType;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly Lazy<string> _sourceFilePath;
 
-
-        public Type ReflectionType => _reflactionType.Value;
+        public Type ReflectionType => _reflectionType.Value;
         public string FullName => _monoTypeDefinition.FullName;
         public string Name => _monoTypeDefinition.Name;
         public string Explanation { get; }
         public string SourceFilePath => _sourceFilePath.Value;
 
-
         internal TypeContainer(TypeDefinition monoTypeDefinition, string explanation)
         {
             _monoTypeDefinition = monoTypeDefinition;
-            _reflactionType = new Lazy<Type>(() =>
+            _reflectionType = new Lazy<Type>(() =>
             {
                 try
                 {
@@ -37,10 +35,9 @@ namespace NetArchTest.Assemblies.PublicUse
                 }
                 return null;
             });
-            _sourceFilePath = new Lazy<string>(() => _monoTypeDefinition.GetFilePath());
+            _sourceFilePath = new Lazy<string>(_monoTypeDefinition.GetFilePath);
             Explanation = explanation;
-        }       
-
+        }
 
         public static implicit operator Type(TypeContainer type)
         {

--- a/sources/NetArchTest/Assemblies/TypeSpec.cs
+++ b/sources/NetArchTest/Assemblies/TypeSpec.cs
@@ -19,14 +19,11 @@ namespace NetArchTest.Assemblies
         public string Explanation { get; set; }
         public string SourceFilePath => _sourceFilePath.Value;
 
-
         public TypeSpec(TypeDefinition definition)
         {
             Definition = definition;
             _sourceFilePath = new Lazy<string>(() => Definition.GetFilePath());
         }
-
-
 
         public TypeContainer CreateWrapper()
         {

--- a/sources/NetArchTest/Condition.cs
+++ b/sources/NetArchTest/Condition.cs
@@ -12,35 +12,31 @@ namespace NetArchTest.Rules
     /// </summary>
     public sealed partial class Condition
     {
-        private readonly RuleContext rule;
-        private readonly ConditionContext context;
-
+        private readonly RuleContext _rule;
+        private readonly ConditionContext _context;
 
         internal Condition(RuleContext rule)
         {
-            this.rule = rule;
-            this.context = rule.ConditionContext;
+            _rule = rule;
+            _context = rule.ConditionContext;
         }
         internal Condition(RuleContext rule, bool should) : this(rule)
-        {           
+        {
             rule.ConditionContext.Should = should;
         }
-       
 
         private ConditionList CreateConditionList()
         {
-            return new ConditionList(rule);
+            return new ConditionList(_rule);
         }
         private void AddFunctionCall(Func<IEnumerable<TypeSpec>, IEnumerable<TypeSpec>> func)
         {
-            context.Sequence.AddFunctionCall(func);
+            _context.Sequence.AddFunctionCall(func);
         }
         private void AddFunctionCall(Func<FunctionSequenceExecutionContext, IEnumerable<TypeSpec>, IEnumerable<TypeSpec>> func)
         {
-            context.Sequence.AddFunctionCall(func);
+            _context.Sequence.AddFunctionCall(func);
         }
-
-
 
         /// <summary>
         /// Selects types are decorated with a specific custom attribut.
@@ -54,7 +50,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types are decorated with a specific custom attribut.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveCustomAttribute<T>()
         {
@@ -73,7 +69,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are not decorated with a specific custom attribute.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveCustomAttribute<T>()
         {
@@ -92,7 +88,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are decorated with a specific custom attribute or derived one.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveCustomAttributeOrInherit<T>()
         {
@@ -111,7 +107,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types are not decorated with a specific custom attribute or derived one.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveCustomAttributeOrInherit<T>()
         {
@@ -130,7 +126,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that inherit a particular type.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList Inherit<T>()
         {
@@ -149,7 +145,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that do not inherit a particular type.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotInherit<T>()
         {
@@ -168,7 +164,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that implement a particular interface.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList ImplementInterface<T>()
         {
@@ -187,13 +183,12 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that do not implement a particular interface.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotImplementInterface<T>()
         {
             return NotImplementInterface(typeof(T));
         }
-
 
         /// <summary>
         /// Selects types that meet a custom rule.
@@ -207,7 +202,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that meet a custom rule.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList MeetCustomRule(Func<TypeDefinition, bool> rule)
         {
@@ -226,7 +221,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that meet a custom rule.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList MeetCustomRule(Func<TypeDefinition, CustomRuleResult> rule)
         {

--- a/sources/NetArchTest/ConditionList.cs
+++ b/sources/NetArchTest/ConditionList.cs
@@ -5,19 +5,17 @@ using NetArchTest.RuleEngine;
 namespace NetArchTest.Rules
 {
     /// <summary>
-    /// A set of conditions and types that have have conjunctions (i.e. "and", "or") and executors (i.e. Types(), GetResult()) applied to them.
+    /// A set of conditions and types that have conjunctions (i.e. "and", "or") and executors (i.e. Types(), GetResult()) applied to them.
     /// </summary>
     public sealed class ConditionList
     {
-        private readonly RuleContext rule;       
-
+        private readonly RuleContext _rule;
 
         internal ConditionList(RuleContext rule)
         {
-            this.rule = rule;          
+            _rule = rule;
         }
-
-
+        
         /// <summary>
         /// Specifies that any subsequent condition should be treated as an "and" condition.
         /// </summary>
@@ -25,7 +23,7 @@ namespace NetArchTest.Rules
         /// <remarks>And() has higher priority than Or() and it is computed first.</remarks>
         public Condition And()
         {
-            return new Condition(rule);
+            return new Condition(_rule);
         }
 
         /// <summary>
@@ -35,10 +33,9 @@ namespace NetArchTest.Rules
         public Condition Or()
         {
             // Create a new group of functions - this has the effect of creating an "or" condition
-            rule.ConditionContext.Sequence.CreateGroup();
-            return new Condition(rule);
+            _rule.ConditionContext.Sequence.CreateGroup();
+            return new Condition(_rule);
         }
-
 
         /// <summary>
         /// Returns an indication of whether all the selected types satisfy the conditions.
@@ -46,7 +43,7 @@ namespace NetArchTest.Rules
         /// <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
         public TestResult GetResult(Options options = null)
         {
-            return rule.GetResult(options);
+            return _rule.GetResult(options);
         }
 
         /// <summary>
@@ -55,13 +52,12 @@ namespace NetArchTest.Rules
         /// <returns>A list of types.</returns>
         public IEnumerable<IType> GetTypes(Options options = null)
         {
-            return rule.GetTypes(options);
+            return _rule.GetTypes(options);
         }
 
-                
         internal IEnumerable<Type> GetReflectionTypes(Options options = null)
         {
-            return rule.GetReflectionTypes(options);
+            return _rule.GetReflectionTypes(options);
         }
     }
 }

--- a/sources/NetArchTest/Condition_Dependencies.cs
+++ b/sources/NetArchTest/Condition_Dependencies.cs
@@ -27,7 +27,7 @@ namespace NetArchTest.Rules
         }
 
         /// <summary>
-        /// Selects types that have a dependency on any of the supplied types and cannot have any other dependency. 
+        /// Selects types that have a dependency on any of the supplied types and cannot have any other dependency.
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
@@ -69,7 +69,6 @@ namespace NetArchTest.Rules
             AddFunctionCall((context, inputTypes) => FunctionDelegates.OnlyHaveDependenciesOnAnyOrNone(context, inputTypes, dependencies, false));
             return CreateConditionList();
         }
-
 
         /// <summary>
         /// Selects types that are used by any of the supplied types.

--- a/sources/NetArchTest/Condition_Metrics.cs
+++ b/sources/NetArchTest/Condition_Metrics.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NetArchTest.Functions;
+﻿using NetArchTest.Functions;
 
 namespace NetArchTest.Rules
 {

--- a/sources/NetArchTest/Condition_Names.cs
+++ b/sources/NetArchTest/Condition_Names.cs
@@ -7,7 +7,7 @@ namespace NetArchTest.Rules
     {
         /// <summary>
         /// Selects types that are exactly of given type. (inheritance is not considered)
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList BeOfType(params Type[] type)
         {
@@ -17,7 +17,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not exactly of given type. (inheritance is not considered)
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotBeOfType(params Type[] type)
         {
@@ -34,7 +34,7 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveName(string name)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, new[] { name }, true));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, [name], true));
             return CreateConditionList();
         }
 
@@ -47,7 +47,7 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveName(string name)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, new[] { name }, false));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, [name], false));
             return CreateConditionList();
         }
 
@@ -82,7 +82,8 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveNameStartingWith(string start)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, new[] { start }, true));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, [start
+            ], true));
             return CreateConditionList();
         }
 
@@ -95,7 +96,8 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveNameStartingWith(string start)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, new[] { start }, false));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, [start
+            ], false));
             return CreateConditionList();
         }
 
@@ -108,7 +110,7 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveNameEndingWith(string end)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, new[] { end }, true));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, [end], true));
             return CreateConditionList();
         }
 
@@ -121,10 +123,9 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveNameEndingWith(string end)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, new[] { end }, false));
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, [end], false));
             return CreateConditionList();
         }
-               
 
         /// <summary>
         /// Selects types that reside in a particular namespace.

--- a/sources/NetArchTest/Condition_Special.cs
+++ b/sources/NetArchTest/Condition_Special.cs
@@ -36,7 +36,6 @@ namespace NetArchTest.Rules
             return CreateConditionList();
         }
 
-
         /// <summary>
         /// Selects types that are stateless, they do not have instance state
         /// </summary>
@@ -87,7 +86,6 @@ namespace NetArchTest.Rules
             return CreateConditionList();
         }
 
-
         /// <summary>
         /// For each type, check if the name is consistent with its source file name.
         /// </summary>
@@ -113,7 +111,7 @@ namespace NetArchTest.Rules
             AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveFilePathMatchingTypeNamespace(context, inputTypes, true));
             return CreateConditionList();
         }
-               
+
         /// <summary>
         /// For each type, check if a matching type with the given name exists.
         /// </summary>
@@ -123,7 +121,6 @@ namespace NetArchTest.Rules
             AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveMatchingTypeWithName(context, inputTypes, getMatchingTypeName, true));
             return CreateConditionList();
         }
-
 
         /// <summary>
         /// Selects types that have at least one instance public constructor.

--- a/sources/NetArchTest/Dependencies/DataStructures/CachedNamespaceTree.cs
+++ b/sources/NetArchTest/Dependencies/DataStructures/CachedNamespaceTree.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.Dependencies.DataStructures
-{  
+{
     using System.Collections.Generic;
-    using System.Linq;   
+    using System.Linq;
     using Mono.Cecil;
 
     internal class CachedNamespaceTree : ISearchTree
@@ -9,28 +9,26 @@
         /// <summary> The list of dependencies being searched for. </summary>
         private readonly NamespaceTree _searchTree;
 
-        public int TerminatedNodesCount { get => _searchTree.TerminatedNodesCount; }
-
+        public int TerminatedNodesCount => _searchTree.TerminatedNodesCount;
 
         public CachedNamespaceTree(IEnumerable<string> dependencies)
         {
             _searchTree = new NamespaceTree(dependencies, true);
         }
 
-
         /// <summary>
-        /// Searching search tree is costly (it requires a lot of operations on strings like SubString, IndexOf).
+        /// Searching a search tree is costly (it requires a lot of operations on strings like SubString, IndexOf).
         /// For a given type we always get the same answer, so let us cache what search tree returns.
-        /// </summary>        
-        private readonly TypeReferenceTree<string[]> _cachedAnswersFromSearchTree = new TypeReferenceTree<string[]>();   
+        /// </summary>
+        private readonly TypeReferenceTree<string[]> _cachedAnswersFromSearchTree = new();
         public IEnumerable<string> GetAllMatchingNames(TypeReference type)
         {
             var node = _cachedAnswersFromSearchTree.GetNode(type);
-            if (node.value == null)
+            if (node.Value == null)
             {
-                node.value = _searchTree.GetAllMatchingNames(type).ToArray();
+                node.Value = _searchTree.GetAllMatchingNames(type).ToArray();
             }
-            return node.value;
+            return node.Value;
         }
 
         public IEnumerable<string> GetAllMatchingNames(string fullName)

--- a/sources/NetArchTest/Dependencies/DataStructures/NamespaceTree.cs
+++ b/sources/NetArchTest/Dependencies/DataStructures/NamespaceTree.cs
@@ -5,7 +5,6 @@
     using System.Diagnostics;
     using System.Text;
     using Mono.Cecil;
-   
 
     /// <summary>
     /// Holds tree structure of full names; child nodes of each parent are indexed for optimal time of search.
@@ -39,7 +38,7 @@
         {
             /// <summary> Maps child namespace to its root node. </summary>
             private Dictionary<string, Node> Nodes { get; } = new Dictionary<string, Node>();
-                        
+
             public bool IsTerminated
             {
                 get; private set;
@@ -59,8 +58,7 @@
             {
                 name = NormalizeString(name);
 
-                Node result;
-                if (!Nodes.TryGetValue(name, out result))
+                if (!Nodes.TryGetValue(name, out var result))
                 {
                     result = new Node();
                     Nodes.Add(name, result);
@@ -78,7 +76,7 @@
             {
                 return Nodes.TryGetValue(NormalizeString(name), out node) && node != null;
             }
-                       
+
             public void Terminate(string fullName)
             {
                 IsTerminated = true;
@@ -94,7 +92,7 @@
         /// <summary> Holds the root for the namespace tree. </summary>
         private readonly Node _root = new Node();
 
-        private static readonly char[] _namespaceSeparators = new char[] { '.', ':', '/', '+' };
+        private static readonly char[] NamespaceSeparators = ['.', ':', '/', '+'];
 
         /// <summary>
         /// Initially fills the tree with given names.
@@ -123,7 +121,7 @@
 
             var deepestNode = _root;
             foreach (var token in TypeParser.Parse(fullName, parseNames))
-            {              
+            {
                 int subnameEndIndex = -1;
                 while (subnameEndIndex != token.Length)
                 {
@@ -171,8 +169,8 @@
                 }
 
                 if (deepestNode.IsTerminated)
-                {                  
-                    yield return deepestNode.FullName;                    
+                {
+                    yield return deepestNode.FullName;
                 }
             }
         }
@@ -180,7 +178,7 @@
         public IEnumerable<string> GetAllMatchingNames(TypeReference reference)
         {
             var deepestNode = _root;
-           
+
             foreach (var token in GetTokens(reference))
             {
                 int subnameEndIndex = -1;
@@ -205,8 +203,8 @@
 
         /// <summary>
         /// Recursively extracts every part from type full name
-        /// </summary>      
-        private IEnumerable<string> GetTokens(TypeReference reference)
+        /// </summary>
+        private static IEnumerable<string> GetTokens(TypeReference reference)
         {
             if ((reference.IsArray == false) && (reference.IsByReference == false) && (reference.IsPointer == false))
             {
@@ -240,7 +238,7 @@
             }
 
             if (reference.IsGenericInstance)
-            {                
+            {
                 var referenceAsGenericInstance = reference as GenericInstanceType;
                 if (referenceAsGenericInstance.HasGenericArguments)
                 {
@@ -249,18 +247,17 @@
                     {
                         foreach (var token in GetTokens(referenceAsGenericInstance.GenericArguments[i]))
                         {
-                            yield return token;                            
+                            yield return token;
                         }
                         yield return ",";
                     }
                 }
             }
-            
         }
 
         private static int GetSubnameEndIndex(string namespaceFullName, int subnameStartIndex)
         {
-            int nextSeparatorIndex = namespaceFullName.IndexOfAny(_namespaceSeparators, subnameStartIndex);
+            int nextSeparatorIndex = namespaceFullName.IndexOfAny(NamespaceSeparators, subnameStartIndex);
             if (nextSeparatorIndex < 0)
             {
                 nextSeparatorIndex = namespaceFullName.Length;

--- a/sources/NetArchTest/Dependencies/DataStructures/TypeReferenceTree.cs
+++ b/sources/NetArchTest/Dependencies/DataStructures/TypeReferenceTree.cs
@@ -1,24 +1,19 @@
 ﻿namespace NetArchTest.Dependencies.DataStructures
 {
-    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
-    using System.Text;
     using Mono.Cecil;
-    
 
     /// <summary>
     /// Similar tree to <see cref="NamespaceTree"/>, but this is aware of the structure of type full name,
     /// which allows traversing tree without allocating new strings.
-    /// </summary>   
+    /// </summary>
     internal class TypeReferenceTree<T>
     {
         private readonly StartOfTypeNode _root = new StartOfTypeNode();
 
-        
         public NameNode GetNode(TypeReference reference)
-        {          
+        {
             return TraverseThroughReferenceName(reference, _root);
         }
 
@@ -29,7 +24,7 @@
             {
                 deepestNameNode = startOfTypeNode.GetNamespace(reference.GetNamespace()).GetName(reference.Name);
                 deepestNameNode = GoDeeperIntoGenericArgumentList(reference, deepestNameNode);
-            } 
+            }
             else
             {
                 var referenceAsTypeSpecification = reference as TypeSpecification;
@@ -51,42 +46,42 @@
                     {
                         deepestNameNode = TraverseThroughReferenceName(referenceAsGenericInstance.GenericArguments[i], startOfTypeNode);
                         if (i < referenceAsGenericInstance.GenericArguments.Count - 1) startOfTypeNode = deepestNameNode.AddAnotherArgument();
-                    }                    
+                    }
                 }
                 deepestNameNode = deepestNameNode.EndArgumentList();
             }
             return deepestNameNode;
         }
 
-        [DebuggerDisplay("StartOfTypeNode (namespaces : {namespaces.Count})")]
+        [DebuggerDisplay("StartOfTypeNode (namespaces : {Namespaces.Count})")]
         public sealed class StartOfTypeNode
         {
-            private Dictionary<string, NamespaceNode> namespaces { get; set; } = new Dictionary<string, NamespaceNode>();
+            private Dictionary<string, NamespaceNode> Namespaces { get; set; } = new Dictionary<string, NamespaceNode>();
 
             public NamespaceNode GetNamespace(string @namespace)
             {
                 NamespaceNode result;
-                if (!namespaces.TryGetValue(@namespace, out result))
+                if (!Namespaces.TryGetValue(@namespace, out result))
                 {
                     result = new NamespaceNode();
-                    namespaces.Add(@namespace, result);
+                    Namespaces.Add(@namespace, result);
                 }
                 return result;
             }
         }
 
-        [DebuggerDisplay("NamespaceNode (names : {names.Count})")]
+        [DebuggerDisplay("NamespaceNode (names : {Names.Count})")]
         public sealed class NamespaceNode
         {
-            private Dictionary<string, NameNode> names { get; set; } = new Dictionary<string, NameNode>();
+            private Dictionary<string, NameNode> Names { get; set; } = new Dictionary<string, NameNode>();
 
             public NameNode GetName(string name)
-            {                
+            {
                 NameNode result;
-                if (!names.TryGetValue(name, out result))
+                if (!Names.TryGetValue(name, out result))
                 {
                     result = new NameNode();
-                    names.Add(name, result);
+                    Names.Add(name, result);
                 }
                 return result;
             }
@@ -95,21 +90,20 @@
         [DebuggerDisplay("NameNode")]
         public sealed class NameNode
         {
-            public T value;
-            private StartOfTypeNode startNode;
-            private StartOfTypeNode andNode;
-            private Dictionary<int, NameNode> typeSpecifications { get; set; }
-
+            public T Value;
+            private StartOfTypeNode _startNode;
+            private StartOfTypeNode _andNode;
+            private Dictionary<int, NameNode> TypeSpecifications { get; set; }
 
             public StartOfTypeNode StartArgumentList()
             {
-                startNode = startNode ?? new StartOfTypeNode();
-                return startNode;
+                _startNode = _startNode ?? new StartOfTypeNode();
+                return _startNode;
             }
             public StartOfTypeNode AddAnotherArgument()
             {
-                andNode = andNode ?? new StartOfTypeNode();
-                return andNode;
+                _andNode = _andNode ?? new StartOfTypeNode();
+                return _andNode;
             }
             public NameNode EndArgumentList()
             {
@@ -119,7 +113,7 @@
             }
             public NameNode AddTypeSpecification(TypeSpecification typeSpecification)
             {
-                typeSpecifications = typeSpecifications ?? new Dictionary<int, NameNode>();
+                TypeSpecifications = TypeSpecifications ?? new Dictionary<int, NameNode>();
 
                 int specificationNumber = (int)typeSpecification.MetadataType;
                 if (typeSpecification.IsArray)
@@ -132,10 +126,10 @@
                 }
 
                 NameNode result;
-                if (!typeSpecifications.TryGetValue(specificationNumber, out result))
+                if (!TypeSpecifications.TryGetValue(specificationNumber, out result))
                 {
                     result = new NameNode();
-                    typeSpecifications.Add(specificationNumber, result);
+                    TypeSpecifications.Add(specificationNumber, result);
                 }
                 return result;
             }

--- a/sources/NetArchTest/Dependencies/DependencySearch.cs
+++ b/sources/NetArchTest/Dependencies/DependencySearch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NetArchTest.Assemblies;
 using NetArchTest.Dependencies.DataStructures;
@@ -12,49 +11,47 @@ namespace NetArchTest.Dependencies
     /// </summary>
     internal class DependencySearch
     {
-        private readonly bool explainYourself;
-        private readonly IDependencyFilter dependencyFilter;
-        private readonly bool serachForDependencyInFieldConstant;
+        private readonly bool _explainYourself;
+        private readonly IDependencyFilter _dependencyFilter;
+        private readonly bool _searchForDependencyInFieldConstant;
 
-
-        public DependencySearch(bool explainYourself, bool serachForDependencyInFieldConstant = false, IDependencyFilter dependencyFilter = null)
+        public DependencySearch(bool explainYourself, bool searchForDependencyInFieldConstant = false, IDependencyFilter dependencyFilter = null)
         {
-            this.explainYourself = explainYourself;
-            this.dependencyFilter = dependencyFilter;
-            this.serachForDependencyInFieldConstant = serachForDependencyInFieldConstant;
+            _explainYourself = explainYourself;
+            _dependencyFilter = dependencyFilter;
+            _searchForDependencyInFieldConstant = searchForDependencyInFieldConstant;
         }
-
 
         /// <summary>
         /// Finds types that have a dependency on any item in the given list of dependencies.
         /// </summary>
         public IEnumerable<TypeSpec> FindTypesThatHaveDependencyOnAny(IEnumerable<TypeSpec> input, IEnumerable<string> dependencies)
-        {  
-            return FindTypes(input, HaveDependency_CheckingStrategy.TypeOfCheck.HaveDependencyOnAny, dependencies);           
+        {
+            return FindTypes(input, HaveDependencyCheckingStrategy.TypeOfCheck.HaveDependencyOnAny, dependencies);
         }
 
         /// <summary>
         /// Finds types that have a dependency on every item in the given list of dependencies.
-        /// </summary>      
+        /// </summary>
         public IEnumerable<TypeSpec> FindTypesThatHaveDependencyOnAll(IEnumerable<TypeSpec> input, IEnumerable<string> dependencies)
-        {  
-            return FindTypes(input, HaveDependency_CheckingStrategy.TypeOfCheck.HaveDependencyOnAll, dependencies);         
+        {
+            return FindTypes(input, HaveDependencyCheckingStrategy.TypeOfCheck.HaveDependencyOnAll, dependencies);
         }
 
         /// <summary>
         /// Finds types that may have a dependency on any item in the given list of dependencies, but cannot have a dependency that is not in the list.
-        /// </summary>             
+        /// </summary>
         public IEnumerable<TypeSpec> FindTypesThatOnlyHaveDependencyOnAnyOrNone(IEnumerable<TypeSpec> input, IEnumerable<string> dependencies)
-        {           
-            return FindTypes(input, HaveDependency_CheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAnyOrNone, dependencies);
+        {
+            return FindTypes(input, HaveDependencyCheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAnyOrNone, dependencies);
         }
 
         /// <summary>
         /// Finds types that have a dependency on any item in the given list of dependencies, but cannot have a dependency that is not in the list.
-        /// </summary>      
+        /// </summary>
         public IEnumerable<TypeSpec> FindTypesThatOnlyHaveDependencyOnAny(IEnumerable<TypeSpec> input, IEnumerable<string> dependencies)
         {
-            return FindTypes(input, HaveDependency_CheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAny, dependencies);
+            return FindTypes(input, HaveDependencyCheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAny, dependencies);
         }
 
         /// <summary>
@@ -62,31 +59,29 @@ namespace NetArchTest.Dependencies
         /// </summary>
         public IEnumerable<TypeSpec> FindTypesThatOnlyOnlyHaveDependencyOnAll(IEnumerable<TypeSpec> input, IEnumerable<string> dependencies)
         {
-            return FindTypes(input, HaveDependency_CheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAll, dependencies);
+            return FindTypes(input, HaveDependencyCheckingStrategy.TypeOfCheck.OnlyHaveDependenciesOnAll, dependencies);
         }
 
-        private IEnumerable<TypeSpec> FindTypes(IEnumerable<TypeSpec> input, HaveDependency_CheckingStrategy.TypeOfCheck typeOfCheck, IEnumerable<string> dependencies)
-        {           
+        private IEnumerable<TypeSpec> FindTypes(IEnumerable<TypeSpec> input, HaveDependencyCheckingStrategy.TypeOfCheck typeOfCheck, IEnumerable<string> dependencies)
+        {
             var searchTree = new CachedNamespaceTree(dependencies);
-            var context = new TypeCheckingContext(serachForDependencyInFieldConstant, explainYourself, dependencyFilter);
+            var context = new TypeCheckingContext(_searchForDependencyInFieldConstant, _explainYourself, _dependencyFilter);
 
             foreach (var type in input)
             {
-                var strategy = new HaveDependency_CheckingStrategy(typeOfCheck, searchTree);                
+                var strategy = new HaveDependencyCheckingStrategy(typeOfCheck, searchTree);
                 context.PerformCheck(type, strategy);
-                type.IsPassing = strategy.DoesTypePassCheck();                
+                type.IsPassing = strategy.DoesTypePassCheck();
             }
 
             return input;
         }
 
-
         public IEnumerable<TypeSpec> FindTypesThatAreUsedByAny(IEnumerable<TypeSpec> input, IEnumerable<string> users, IEnumerable<TypeSpec> allTypes)
         {
             var filterTree = new CachedNamespaceTree(users);
-            var context = new TypeCheckingContext(serachForDependencyInFieldConstant, explainYourself, dependencyFilter);
-            var strategy = new AreUsedBy_CheckingStrategy();
-
+            var context = new TypeCheckingContext(_searchForDependencyInFieldConstant, _explainYourself, _dependencyFilter);
+            var strategy = new AreUsedByCheckingStrategy();
 
             foreach (var type in allTypes)
             {
@@ -97,8 +92,8 @@ namespace NetArchTest.Dependencies
                     context.PerformCheck(type, strategy);
                 }
             }
-            
-            foreach (var type in input) 
+
+            foreach (var type in input)
             {
                 type.IsPassing = strategy.IsTypeUsed(type.Definition);
             }

--- a/sources/NetArchTest/Dependencies/TypeCheckingStrategy.cs
+++ b/sources/NetArchTest/Dependencies/TypeCheckingStrategy.cs
@@ -12,10 +12,10 @@ namespace NetArchTest.Dependencies
         bool CanWeSkipFurtherSearch();
         void CheckType(string dependencyTypeFullName);
         void CheckType(TypeReference dependency);
-        string ExplainWhy();      
+        string ExplainWhy();
     }
 
-    internal class HaveDependency_CheckingStrategy : ITypeCheckingStrategy
+    internal class HaveDependencyCheckingStrategy : ITypeCheckingStrategy
     {
         public enum TypeOfCheck
         {
@@ -29,20 +29,18 @@ namespace NetArchTest.Dependencies
         private readonly TypeOfCheck _typeOfCheck;
         private readonly ISearchTree _dependencySearchTree;
         /// <summary> The list of dependencies that have been found in the search.</summary>
-        private HashSet<string> _foundDependencies = new HashSet<string>();
+        private readonly HashSet<string> _foundDependencies = [];
         private bool _hasDependencyFromOutsideOfSearchTree;
 
-        TypeReference lastFoundDependency = null;
-        TypeReference lastFoundDependencyOutsideOfSearchTree = null;
+        TypeReference _lastFoundDependency = null;
+        TypeReference _lastFoundDependencyOutsideOfSearchTree = null;
 
-
-        public HaveDependency_CheckingStrategy(TypeOfCheck searchType, ISearchTree dependencySearchTree)
+        public HaveDependencyCheckingStrategy(TypeOfCheck searchType, ISearchTree dependencySearchTree)
         {
             _typeOfCheck = searchType;
             _dependencySearchTree = dependencySearchTree;
             _hasDependencyFromOutsideOfSearchTree = false;
         }
-
 
         public bool DoesTypePassCheck()
         {
@@ -72,29 +70,22 @@ namespace NetArchTest.Dependencies
                     {
                         return "Has dependency on all provided inputs";
                     }
-                    else
-                    {
-                        return string.Empty;
-                    }
+
+                    return string.Empty;
                 case TypeOfCheck.HaveDependencyOnAny:
                     if (isTypeFound)
                     {
-                        return $"Has dependency on: {lastFoundDependency}";
+                        return $"Has dependency on: {_lastFoundDependency}";
                     }
-                    else
-                    {
-                        return "Does not have a dependency on any provided inputs";
-                    }
+
+                    return "Does not have a dependency on any provided inputs";
                 case TypeOfCheck.OnlyHaveDependenciesOnAnyOrNone:
                     if (isTypeFound)
                     {
                         return "Does not have a dependency outside of provided inputs";
                     }
-                    else
-                    {
-                        return $"Has dependency on: {lastFoundDependencyOutsideOfSearchTree}";
-                    }
-                    break;
+
+                    return $"Has dependency on: {_lastFoundDependencyOutsideOfSearchTree}";
             }
             throw new NotImplementedException();
         }
@@ -102,8 +93,8 @@ namespace NetArchTest.Dependencies
         /// <summary>
         /// If we already know the final answer to the question if type was found,
         /// doing another search will not change the result
-        /// </summary>     
-        public bool CanWeSkipFurtherSearch()    
+        /// </summary>
+        public bool CanWeSkipFurtherSearch()
         {
             switch (_typeOfCheck)
             {
@@ -140,7 +131,7 @@ namespace NetArchTest.Dependencies
                 {
                     _foundDependencies.Add(match);
                 }
-                lastFoundDependency = dependency;
+                _lastFoundDependency = dependency;
             }
             else
             {
@@ -154,24 +145,21 @@ namespace NetArchTest.Dependencies
                     if (!isGlobalAnonymousCompilerGeneratedType)
                     {
                         _hasDependencyFromOutsideOfSearchTree = true;
-                        lastFoundDependencyOutsideOfSearchTree = dependency;
+                        _lastFoundDependencyOutsideOfSearchTree = dependency;
                     }
                 }
             }
         }
     }
 
-
-    internal class AreUsedBy_CheckingStrategy : ITypeCheckingStrategy
+    internal class AreUsedByCheckingStrategy : ITypeCheckingStrategy
     {
-        HashSet<string> usedTypes = new HashSet<string>();
+        HashSet<string> _usedTypes = new HashSet<string>();
 
-       
         public bool IsTypeUsed(TypeReference type)
         {
-            return usedTypes.Contains(type.FullName);
+            return _usedTypes.Contains(type.FullName);
         }
-
 
         public bool CanWeSkipFurtherSearch()
         {
@@ -180,17 +168,16 @@ namespace NetArchTest.Dependencies
 
         public void CheckType(string dependencyTypeFullName)
         {
-             
         }
 
         public void CheckType(TypeReference dependency)
         {
-            usedTypes.Add(dependency.FullName);
+            _usedTypes.Add(dependency.FullName);
         }
 
         public string ExplainWhy()
         {
             return "todo";
-        }     
+        }
     }
 }

--- a/sources/NetArchTest/Dependencies/TypeParser.cs
+++ b/sources/NetArchTest/Dependencies/TypeParser.cs
@@ -3,18 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using System.Text;   
 
     internal static class TypeParser
     {
-        static readonly Type mono_TypeParserType = Type.GetType("Mono.Cecil.TypeParser, " + typeof(Mono.Cecil.TypeReference).Assembly);
-        static readonly Type mono_TypeType = Type.GetType("Mono.Cecil.TypeParser+Type, " + typeof(Mono.Cecil.TypeReference).Assembly);
-        static readonly MethodInfo mono_ParseTypeMethod = mono_TypeParserType.GetMethod("ParseType", BindingFlags.Instance | BindingFlags.NonPublic);
-        static readonly FieldInfo mono_type_fullnameField = mono_TypeType.GetField("type_fullname", BindingFlags.Instance | BindingFlags.Public);
-        static readonly FieldInfo mono_nested_namesField = mono_TypeType.GetField("nested_names", BindingFlags.Instance | BindingFlags.Public);
-        static readonly FieldInfo mono_generic_argumentsField = mono_TypeType.GetField("generic_arguments", BindingFlags.Instance | BindingFlags.Public);
-        static readonly FieldInfo mono_specsField = mono_TypeType.GetField("specs", BindingFlags.Instance | BindingFlags.Public);
-
+        static readonly Type MonoTypeParserType = Type.GetType("Mono.Cecil.TypeParser, " + typeof(Mono.Cecil.TypeReference).Assembly);
+        static readonly Type MonoTypeType = Type.GetType("Mono.Cecil.TypeParser+Type, " + typeof(Mono.Cecil.TypeReference).Assembly);
+        static readonly MethodInfo MonoParseTypeMethod = MonoTypeParserType.GetMethod("ParseType", BindingFlags.Instance | BindingFlags.NonPublic);
+        static readonly FieldInfo MonoTypeFullnameField = MonoTypeType.GetField("type_fullname", BindingFlags.Instance | BindingFlags.Public);
+        static readonly FieldInfo MonoNestedNamesField = MonoTypeType.GetField("nested_names", BindingFlags.Instance | BindingFlags.Public);
+        static readonly FieldInfo MonoGenericArgumentsField = MonoTypeType.GetField("generic_arguments", BindingFlags.Instance | BindingFlags.Public);
+        static readonly FieldInfo MonoSpecsField = MonoTypeType.GetField("specs", BindingFlags.Instance | BindingFlags.Public);
 
         public static IEnumerable<string> Parse(string fullName, bool parseNames)
         {
@@ -23,9 +21,10 @@
                 yield return fullName;
                 yield break;
             }
-           
-            var monoTypeParser = Activator.CreateInstance(mono_TypeParserType, BindingFlags.Instance | BindingFlags.NonPublic, null, args: new object[] { fullName }, null);
-            var monoType = mono_ParseTypeMethod.Invoke(monoTypeParser, new object[] { false });
+
+            var monoTypeParser = Activator.CreateInstance(MonoTypeParserType, BindingFlags.Instance | BindingFlags.NonPublic, null, args:
+                [fullName], null);
+            var monoType = MonoParseTypeMethod.Invoke(monoTypeParser, [false]);
             foreach (var token in WalkThroughMonoType(monoType))
             {
                 yield return token;
@@ -34,18 +33,18 @@
 
         private static IEnumerable<string> WalkThroughMonoType(object monoType)
         {
-            yield return mono_type_fullnameField.GetValue(monoType) as string;
-            
-            var nested = mono_nested_namesField.GetValue(monoType) as string[];
+            yield return MonoTypeFullnameField.GetValue(monoType) as string;
+
+            var nested = MonoNestedNamesField.GetValue(monoType) as string[];
             if (nested != null)
             {
                 foreach (var nestedName in nested)
                 {
                     yield return nestedName;
                 }
-            } 
+            }
 
-            var generics = mono_generic_argumentsField.GetValue(monoType) as object[];
+            var generics = MonoGenericArgumentsField.GetValue(monoType) as object[];
             if (generics != null)
             {
                 yield return "<";
@@ -59,7 +58,7 @@
                 }
             }
 
-            var specs = mono_specsField.GetValue(monoType) as int[];
+            var specs = MonoSpecsField.GetValue(monoType) as int[];
             if (specs != null)
             {
                 for (int i = 0; i < specs.Length; ++i)
@@ -84,21 +83,19 @@
             }
         }
 
-
-
-
         public static string ParseReflectionNameToRuntimeName(string fullName)
         {
-            var monoTypeParser = Activator.CreateInstance(mono_TypeParserType, BindingFlags.Instance | BindingFlags.NonPublic, null, args: new object[] { fullName }, null);
-            var monoType = mono_ParseTypeMethod.Invoke(monoTypeParser, new object[] { false });
+            var monoTypeParser = Activator.CreateInstance(MonoTypeParserType, BindingFlags.Instance | BindingFlags.NonPublic, null, args:
+                [fullName], null);
+            var monoType = MonoParseTypeMethod.Invoke(monoTypeParser, [false]);
             return string.Concat(WalkThroughMonoType2(monoType));
         }
 
         private static IEnumerable<string> WalkThroughMonoType2(object monoType)
         {
-            yield return mono_type_fullnameField.GetValue(monoType) as string;
+            yield return MonoTypeFullnameField.GetValue(monoType) as string;
 
-            var nested = mono_nested_namesField.GetValue(monoType) as string[];
+            var nested = MonoNestedNamesField.GetValue(monoType) as string[];
             if (nested != null)
             {
                 foreach (var nestedName in nested)
@@ -108,7 +105,7 @@
                 }
             }
 
-            var generics = mono_generic_argumentsField.GetValue(monoType) as object[];
+            var generics = MonoGenericArgumentsField.GetValue(monoType) as object[];
             if (generics != null)
             {
                 yield return "<";
@@ -127,7 +124,7 @@
                 yield return ">";
             }
 
-            var specs = mono_specsField.GetValue(monoType) as int[];
+            var specs = MonoSpecsField.GetValue(monoType) as int[];
             if (specs != null)
             {
                 for (int i = 0; i < specs.Length; ++i)
@@ -151,7 +148,5 @@
                 }
             }
         }
-      
-
     }
 }

--- a/sources/NetArchTest/Extensions/Mono.Cecil/FieldDefinitionExtensions.cs
+++ b/sources/NetArchTest/Extensions/Mono.Cecil/FieldDefinitionExtensions.cs
@@ -1,9 +1,9 @@
 namespace Mono.Cecil
 {
-    static internal class FieldDefinitionExtensions
-    {       
+    internal static class FieldDefinitionExtensions
+    {
         public static bool IsReadonly(this FieldDefinition fieldDefinition)
-        {           
+        {
             return fieldDefinition.IsInitOnly || fieldDefinition.HasConstant || fieldDefinition.IsCompilerControlled;
         }
         public static bool IsReadonlyExternally(this FieldDefinition fieldDefinition)
@@ -14,7 +14,6 @@ namespace Mono.Cecil
             }
             return fieldDefinition.IsReadonly();
         }
-
 
         public static bool IsNullable(this FieldDefinition fieldDefinition)
         {

--- a/sources/NetArchTest/Extensions/Mono.Cecil/PropertyDefinitionExtensions.cs
+++ b/sources/NetArchTest/Extensions/Mono.Cecil/PropertyDefinitionExtensions.cs
@@ -1,7 +1,7 @@
 namespace Mono.Cecil
 {
-    static internal class PropertyDefinitionExtensions
-    {        
+    internal static class PropertyDefinitionExtensions
+    {
         public static bool IsReadonly(this PropertyDefinition propertyDefinition)
         {
             if (propertyDefinition.SetMethod == null)
@@ -9,7 +9,7 @@ namespace Mono.Cecil
                 return true;
             }
             else
-            {                
+            {
                 if (propertyDefinition.IsInitOnly())
                 {
                     return true;
@@ -32,7 +32,6 @@ namespace Mono.Cecil
             return propertyDefinition.SetMethod?.ReturnType.FullName == "System.Void modreq(System.Runtime.CompilerServices.IsExternalInit)";
         }
 
-       
         public static bool IsNullable(this PropertyDefinition propertyDefinition)
         {
             return propertyDefinition.PropertyType.IsNullable();

--- a/sources/NetArchTest/Extensions/Mono.Cecil/TypeDefinitionExtensions.GetLOC.cs
+++ b/sources/NetArchTest/Extensions/Mono.Cecil/TypeDefinitionExtensions.GetLOC.cs
@@ -6,7 +6,7 @@ namespace NetArchTest.Extensions.Mono.Cecil
     {
         internal static int GetNumberOfLogicalLinesOfCode(this TypeDefinition type)
         {
-            int count = 0; 
+            int count = 0;
 
             if (type.HasMethods)
             {
@@ -16,14 +16,13 @@ namespace NetArchTest.Extensions.Mono.Cecil
                     if (method.IsGeneratedCode()) continue;
                     if (method.DeclaringType.Module.HasSymbols == false) continue;
 
-                    var methodLLOC = CountLogicalLinesOfCode(method);
-                    count += methodLLOC;
+                    var methodLloc = CountLogicalLinesOfCode(method);
+                    count += methodLloc;
                 }
             }
 
             return count;
         }
-
 
         private static int CountLogicalLinesOfCode(MethodDefinition method)
         {
@@ -40,7 +39,7 @@ namespace NetArchTest.Extensions.Mono.Cecil
                 // special value for PDB (so that debuggers can ignore a line)
                 if (line == 0xFEEFEE)
                     continue;
-                
+
                 if (line > lastLine)
                     count++;
 

--- a/sources/NetArchTest/Extensions/Mono.Cecil/TypeDefinitionExtensions.cs
+++ b/sources/NetArchTest/Extensions/Mono.Cecil/TypeDefinitionExtensions.cs
@@ -23,7 +23,7 @@ namespace Mono.Cecil
             }
 
             return false;
-        }        
+        }
 
         private static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition classType)
         {
@@ -34,7 +34,7 @@ namespace Mono.Cecil
         }
 
         internal static bool IsAlmostEqualTo(this TypeReference child, TypeDefinition parent)
-        {            
+        {
             if (child is GenericInstanceType genericInstanceTypeB)
             {
                 if (parent.IsSameTypeAs(genericInstanceTypeB.ElementType))
@@ -51,8 +51,6 @@ namespace Mono.Cecil
             return false;
         }
 
-
-
         /// <summary>
         /// Convert the definition to a <see cref="Type"/> object instance.
         /// </summary>
@@ -64,13 +62,9 @@ namespace Mono.Cecil
             return Type.GetType(string.Concat(fullName, ", ", typeDefinition.Module.Assembly.FullName), true);
         }
 
-
-
-
-
         /// <summary>
         /// Tests whether a class is immutable, i.e. all public fields are readonly and properties have no set method
-        /// </summary>      
+        /// </summary>
         internal static bool IsImmutable(this TypeDefinition typeDefinition)
         {
             var propertiesAreReadonly = typeDefinition.Properties.All(p => p.IsReadonly());
@@ -86,8 +80,6 @@ namespace Mono.Cecil
             var eventsAreReadonly = typeDefinition.Events.All(f => f.IsReadonlyExternally());
             return propertiesAreReadonly && fieldsAreReadonly && eventsAreReadonly;
         }
-
-
 
         internal static bool OnlyHasNullableMembers(this TypeDefinition typeDefinition)
         {
@@ -110,7 +102,7 @@ namespace Mono.Cecil
 
         /// <summary>
         /// Returns namespace of the given type, if the type is nested, namespace of containing type is returned instead
-        /// </summary>        
+        /// </summary>
         /// <remarks>
         /// For nested classes this will take the name of the declaring class. See https://github.com/BenMorris/NetArchTest/issues/73
         /// </remarks>
@@ -123,8 +115,6 @@ namespace Mono.Cecil
             return typeDefinition.Namespace;
         }
 
-
-
         internal static string GetNameWithoutGenericPart(this TypeDefinition typeDefinition)
         {
             if (typeDefinition.HasGenericParameters == false)
@@ -134,10 +124,6 @@ namespace Mono.Cecil
             return typeDefinition.Name.RemoveGenericPart();
         }
 
-
-
-
-
         internal static bool IsDelegate(this TypeDefinition typeDefinition)
         {
             return typeDefinition.IsClass && typeDefinition.BaseType?.FullName == "System.MulticastDelegate";
@@ -146,8 +132,6 @@ namespace Mono.Cecil
         {
             return typeDefinition.IsValueType && typeDefinition.BaseType?.FullName == "System.ValueType";
         }
-
-
 
         internal static string GetFilePath(this TypeDefinition typeDefinition)
         {
@@ -168,7 +152,7 @@ namespace Mono.Cecil
         }
 
         internal static bool IsStateless(this TypeDefinition type)
-        {            
+        {
             if (type.HasFields)
             {
                 foreach (var field in type.Fields)
@@ -183,11 +167,11 @@ namespace Mono.Cecil
             return true;
         }
         internal static bool IsStaticless(this TypeDefinition type)
-        {           
+        {
             if (type.HasFields)
             {
                 foreach (var field in type.Fields)
-                {                    
+                {
                     if (field.IsStatic && field.HasConstant == false)
                     {
                         return false;

--- a/sources/NetArchTest/Extensions/Mono.Cecil/TypeReferenceExtensions.cs
+++ b/sources/NetArchTest/Extensions/Mono.Cecil/TypeReferenceExtensions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Mono.Cecil
 {
-    static internal class TypeReferenceExtensions
+    internal static class TypeReferenceExtensions
     {
         /// <summary>
         /// Tests whether a Type is a non-nullable value type
@@ -16,7 +16,7 @@ namespace Mono.Cecil
 
         /// <summary>
         /// Returns namespace of the given type, if the type is nested, namespace of containing type is returned instead
-        /// </summary>        
+        /// </summary>
         public static string GetNamespace(this TypeReference typeReference)
         {
             if (typeReference.IsNested)
@@ -25,7 +25,6 @@ namespace Mono.Cecil
             }
             return typeReference.Namespace;
         }
-
 
         public static string GetFullNameWithoutGenericParameters(this TypeReference typeReference)
         {

--- a/sources/NetArchTest/Extensions/System/Runtime.CompilerServices/IsExternalInit.cs
+++ b/sources/NetArchTest/Extensions/System/Runtime.CompilerServices/IsExternalInit.cs
@@ -1,4 +1,4 @@
 ﻿namespace System.Runtime.CompilerServices
 {
-    internal static class IsExternalInit { }
+    internal static class IsExternalInit;
 }

--- a/sources/NetArchTest/Extensions/System/StringExtensions.cs
+++ b/sources/NetArchTest/Extensions/System/StringExtensions.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace System
+﻿namespace System
 {
     internal static class StringExtensions
     {
         public static string RemoveGenericPart(this string name)
         {
-            if (string.IsNullOrEmpty(name)) 
+            if (string.IsNullOrEmpty(name))
                 return name;
 
             int index = name.LastIndexOf('`');
@@ -19,12 +15,11 @@ namespace System
             return name;
         }
 
-
         public static string RuntimeNameToReflectionName(this string cliName)
         {
             // Nested types have a forward slash that should be replaced with "+"
             // C++ template instantiations contain comma separator for template arguments,
-            // getting address operators and pointer type designations which should be prefixed by backslash
+            // getting address operators and pointer type designations which backslash should prefix
             var fullName = cliName.Replace("/", "+")
                 .Replace(",", "\\,")
                 .Replace("&", "\\&")
@@ -34,7 +29,7 @@ namespace System
 
         public static string ReflectionNameToRuntimeName(this string typeName)
         {
-            var fullName = typeName.Replace("+", "/");                
+            var fullName = typeName.Replace("+", "/");
             return fullName;
         }
     }

--- a/sources/NetArchTest/Extensions/System/TypeExtensions.cs
+++ b/sources/NetArchTest/Extensions/System/TypeExtensions.cs
@@ -4,7 +4,7 @@ using NetArchTest.Dependencies;
 
 namespace System
 {
-    static internal class TypeExtensions
+    internal static class TypeExtensions
     {
         public static TypeDefinition ToTypeDefinition(this Type type)
         {
@@ -23,14 +23,9 @@ namespace System
 
         public static string GetNormalizedFullName(this Type type)
         {
-            var name = type.Name;
-            var fullName = type.FullName;
-            var toString = type.ToString();
-            var assemblyQualifiedName = type.AssemblyQualifiedName;
-
             var monoName = TypeParser.ParseReflectionNameToRuntimeName(type.FullName);
 
-            if (type.IsGenericType && type.ContainsGenericParameters == false)
+            if (type.IsGenericType && !type.ContainsGenericParameters)
             {
                 //return toString.ReflectionNameToRuntimeName();
             }

--- a/sources/NetArchTest/Functions/FunctionDelegates.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates.cs
@@ -23,9 +23,9 @@ namespace NetArchTest.Functions
                 return input.Where(c => !c.Definition.CustomAttributes.Any(a => a.AttributeType.IsAlmostEqualTo(target)));
             }
         }
-        
+
         internal static IEnumerable<TypeSpec> HaveCustomAttributeOrInherit(IEnumerable<TypeSpec> input, Type attribute, bool condition)
-        {            
+        {
             var target = attribute.ToTypeDefinition();
 
             if (condition)
@@ -37,14 +37,14 @@ namespace NetArchTest.Functions
                 return input.Where(c => !c.Definition.CustomAttributes.Any(a => a.AttributeType.IsSubclassOf(target) || a.AttributeType.IsAlmostEqualTo(target)));
             }
         }
-        
+
         internal static IEnumerable<TypeSpec> Inherit(IEnumerable<TypeSpec> input, Type type, bool condition)
         {
             if (type.IsInterface)
             {
                 throw new ArgumentException($"The type {type.FullName} is an interface. interfaces are implemented not inherited, please use ImplementInterface instead.");
             }
-            
+
             var target = type.ToTypeDefinition();
 
             if (condition)
@@ -59,15 +59,15 @@ namespace NetArchTest.Functions
 
         internal static IEnumerable<TypeSpec> BeInherited(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, bool condition)
         {
-            var InheritedTypes = new HashSet<string>(context.AllTypes.Select(x => x.Definition.BaseType?.GetFullNameWithoutGenericParameters()).Where(x => x is not null));
-            
+            var inheritedTypes = new HashSet<string>(context.AllTypes.Select(x => x.Definition.BaseType?.GetFullNameWithoutGenericParameters()).Where(x => x is not null));
+
             if (condition)
             {
-                return input.Where(c => InheritedTypes.Contains(c.Definition.FullName));
+                return input.Where(c => inheritedTypes.Contains(c.Definition.FullName));
             }
             else
             {
-                return input.Where(c => !InheritedTypes.Contains(c.Definition.FullName));
+                return input.Where(c => !inheritedTypes.Contains(c.Definition.FullName));
             }
         }
 
@@ -88,7 +88,7 @@ namespace NetArchTest.Functions
             {
                 return input.Where(c => !c.Definition.Interfaces.Any(i => i.InterfaceType.IsAlmostEqualTo(target)));
             }
-        } 
+        }
 
         internal static IEnumerable<TypeSpec> MeetCustomRule(IEnumerable<TypeSpec> input, ICustomRule rule, bool condition)
         {
@@ -139,7 +139,6 @@ namespace NetArchTest.Functions
                 return input.Where(t => !ExecuteCustomRule(t, rule));
             }
         }
-
 
         private static bool ExecuteCustomRule(TypeSpec inputType, Func<TypeDefinition, CustomRuleResult> rule)
         {

--- a/sources/NetArchTest/Functions/FunctionDelegates_Dependencies.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates_Dependencies.cs
@@ -13,7 +13,8 @@ namespace NetArchTest.Functions
         {
             // Get the types that contain the dependencies
             var search = new DependencySearch(context.IsFailPathRun, context.UserOptions.SerachForDependencyInFieldConstant, context.DependencyFilter);
-            var results = search.FindTypesThatHaveDependencyOnAny(input, dependencies);
+            search.FindTypesThatHaveDependencyOnAny(input, dependencies);
+            
             return input.Where(t => t.IsPassing == condition);
         }
 
@@ -22,7 +23,7 @@ namespace NetArchTest.Functions
         {
             // Get the types that contain the dependencies
             var search = new DependencySearch(context.IsFailPathRun, context.UserOptions.SerachForDependencyInFieldConstant, context.DependencyFilter);
-            var results = search.FindTypesThatHaveDependencyOnAll(input, dependencies);
+            search.FindTypesThatHaveDependencyOnAll(input, dependencies);
 
             return input.Where(t => t.IsPassing == condition);
         }
@@ -31,17 +32,16 @@ namespace NetArchTest.Functions
         internal static IEnumerable<TypeSpec> OnlyHaveDependenciesOnAnyOrNone(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, IEnumerable<string> dependencies, bool condition)
         {
             var search = new DependencySearch(context.IsFailPathRun, context.UserOptions.SerachForDependencyInFieldConstant, context.DependencyFilter);
-            var results = search.FindTypesThatOnlyHaveDependencyOnAnyOrNone(input, dependencies);
+            search.FindTypesThatOnlyHaveDependencyOnAnyOrNone(input, dependencies);
 
             return input.Where(t => t.IsPassing == condition);
         }
 
-
-
         internal static IEnumerable<TypeSpec> AreUsedByAny(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, IEnumerable<string> dependencies, bool condition)
         {
             var search = new DependencySearch(context.IsFailPathRun, context.UserOptions.SerachForDependencyInFieldConstant, context.DependencyFilter);
-            var results = search.FindTypesThatAreUsedByAny(input, dependencies, context.AllTypes);
+            search.FindTypesThatAreUsedByAny(input, dependencies, context.AllTypes);
+            
             return input.Where(t => t.IsPassing == condition);
         }
     }

--- a/sources/NetArchTest/Functions/FunctionDelegates_Metrics.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates_Metrics.cs
@@ -8,7 +8,6 @@ namespace NetArchTest.Functions
 {
     internal static partial class FunctionDelegates
     {
-
         internal static IEnumerable<TypeSpec> HaveNumberOfLinesOfCodeFewerThan(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, int number, bool condition)
         {
             if (condition)

--- a/sources/NetArchTest/Functions/FunctionDelegates_Names.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates_Names.cs
@@ -82,7 +82,6 @@ namespace NetArchTest.Functions
             static bool EndsWith(string typeName, string[] lookigFor, StringComparison comparer) => lookigFor.Any(x => typeName.EndsWith(x, comparer));
         }
 
-        
         internal static IEnumerable<TypeSpec> ResideInNamespace(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, string name, bool condition)
         {
             if (condition)
@@ -94,7 +93,7 @@ namespace NetArchTest.Functions
                 return input.Where(c => !c.Definition.GetNamespace().StartsWith(name, context.UserOptions.Comparer));
             }
         }
-        
+
         internal static IEnumerable<TypeSpec> ResideInNamespaceMatching(IEnumerable<TypeSpec> input, string pattern, bool condition)
         {
             Regex r = new Regex(pattern, RegexOptions.IgnoreCase);

--- a/sources/NetArchTest/Functions/FunctionDelegates_Special.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates_Special.cs
@@ -34,7 +34,6 @@ namespace NetArchTest.Functions
             }
         }
 
-
         internal static IEnumerable<TypeSpec> OnlyHaveNullableMembers(IEnumerable<TypeSpec> input, bool condition)
         {
             if (condition)
@@ -58,7 +57,6 @@ namespace NetArchTest.Functions
                 return input.Where(c => !c.Definition.OnlyHasNonNullableMembers());
             }
         }
-
 
         internal static IEnumerable<TypeSpec> BeStateless(IEnumerable<TypeSpec> input, bool condition)
         {
@@ -119,7 +117,7 @@ namespace NetArchTest.Functions
                 if (string.IsNullOrEmpty(sourceFilePath)) return true;
 
                 var fullPath = Path.GetDirectoryName(sourceFilePath);
-                var pathAsNamespace = fullPath.Replace(Path.DirectorySeparatorChar, '.');                
+                var pathAsNamespace = fullPath.Replace(Path.DirectorySeparatorChar, '.');
 
                 return pathAsNamespace.EndsWith(@namespace, comparer);
             }
@@ -138,7 +136,6 @@ namespace NetArchTest.Functions
                 return input.Where(c => !exisitingTypes.Contains(getMatchingTypeName(c.Definition)));
             }
         }
-
 
         internal static IEnumerable<TypeSpec> HavePublicConstructor(FunctionSequenceExecutionContext context, IEnumerable<TypeSpec> input, bool condition)
         {

--- a/sources/NetArchTest/Functions/FunctionDelegates_Traits.cs
+++ b/sources/NetArchTest/Functions/FunctionDelegates_Traits.cs
@@ -7,7 +7,7 @@ using NetArchTest.Assemblies;
 namespace NetArchTest.Functions
 {
     internal static partial class FunctionDelegates
-    {  
+    {
         // Modifiers & Generic
 
         internal static IEnumerable<TypeSpec> BeAbstract(IEnumerable<TypeSpec> input, bool condition)
@@ -50,7 +50,7 @@ namespace NetArchTest.Functions
             }
 
             static bool ClassIsSealed(TypeDefinition c) => !c.IsAbstract && c.IsSealed;
-        }   
+        }
 
         internal static IEnumerable<TypeSpec> BeGeneric(IEnumerable<TypeSpec> input, bool condition)
         {
@@ -70,11 +70,11 @@ namespace NetArchTest.Functions
         {
             if (condition)
             {
-                return Enumerable.Empty<TypeSpec>();
+                return [];
             }
             else
             {
-                return Enumerable.Empty<TypeSpec>();
+                return [];
             }
         }
     }

--- a/sources/NetArchTest/IAssembly.cs
+++ b/sources/NetArchTest/IAssembly.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NetArchTest.Rules
+﻿namespace NetArchTest.Rules
 {
     /// <summary>
     /// Assembly wrapper.
@@ -11,7 +7,7 @@ namespace NetArchTest.Rules
     {
         /// <summary>
         /// FullName of the assembly
-        /// </summary>       
+        /// </summary>
         string FullName { get; }
     }
 }

--- a/sources/NetArchTest/ICustomRule.cs
+++ b/sources/NetArchTest/ICustomRule.cs
@@ -15,8 +15,6 @@ namespace NetArchTest.Rules
         bool MeetsRule(TypeDefinition type);
     }
 
-
-
     /// <summary>
     /// An externally defined rule that can be applied as a condition or a predicate.
     /// </summary>
@@ -30,13 +28,11 @@ namespace NetArchTest.Rules
         CustomRuleResult MeetsRule(TypeDefinition type);
     }
 
-
     public class CustomRuleResult
     {
         public bool IsMet { get; init; }
 
         public string Explanation { get; init; }
-       
 
         public CustomRuleResult(bool isMet, string explanation = null)
         {

--- a/sources/NetArchTest/IType.cs
+++ b/sources/NetArchTest/IType.cs
@@ -6,7 +6,7 @@ namespace NetArchTest.Rules
     /// Type wrapper.
     /// </summary>
     public interface IType
-    { 
+    {
         /// <summary>
         /// System.Type
         /// </summary>
@@ -17,12 +17,12 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// FullName of the type
-        /// </summary>       
+        /// </summary>
         string FullName { get; }
 
         /// <summary>
         /// Name of the type
-        /// </summary>       
+        /// </summary>
         string Name { get; }
 
         /// <summary>

--- a/sources/NetArchTest/NetArchTest.csproj
+++ b/sources/NetArchTest/NetArchTest.csproj
@@ -16,10 +16,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>    
     <PackageId>NetArchTest.eNhancedEdition </PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <LangVersion>11</LangVersion>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <SignAssembly>False</SignAssembly>
-	  <AssemblyOriginatorKeyFile>xKey.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>13</LangVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <SignAssembly>False</SignAssembly>
+    <AssemblyOriginatorKeyFile>xKey.snk</AssemblyOriginatorKeyFile>
+    <WarningsAsErrors>true</WarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +34,13 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.13.1" PrivateAssets="All"/>
+  </ItemGroup>
+
 
   <ItemGroup>
     <None Update="Resources\icon.png">

--- a/sources/NetArchTest/Options.cs
+++ b/sources/NetArchTest/Options.cs
@@ -9,12 +9,10 @@ namespace NetArchTest.Rules
     {
         public static readonly Options Default = new Options();
 
-
         /// <summary>
         /// Allows to specify how strings will be compared, default: InvariantCultureIgnoreCase
         /// </summary>
         public StringComparison Comparer { get; init; } = StringComparison.InvariantCultureIgnoreCase;
-
 
         /// <summary>
         /// Determines if dependency analysis should look for dependency in string field constant, default: false

--- a/sources/NetArchTest/Policies/Policy.cs
+++ b/sources/NetArchTest/Policies/Policy.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.Policies
 {
     using System;
-    using NetArchTest.Rules;
+    using Rules;
 
     /// <summary>
     /// An aggregate of rules and results that can be used for reporting.
@@ -58,6 +58,5 @@
 
             return new PolicyDefinition(func, _name, _description);
         }
-
     }
 }

--- a/sources/NetArchTest/Policies/PolicyDefinition.cs
+++ b/sources/NetArchTest/Policies/PolicyDefinition.cs
@@ -3,8 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using NetArchTest.Rules;
-
+    using Rules;
 
     /// <summary>
     /// An aggregate of rules and results that can be used for reporting.
@@ -41,7 +40,7 @@
         /// Adds a rule to the policy that can optionally be marked with a name and description.
         /// </summary>
         public PolicyDefinition Add(Func<Types, ConditionList> definition, string name, string description)
-        { 
+        {
             if(definition == null)
             {
                 throw new ArgumentNullException(nameof(definition));

--- a/sources/NetArchTest/Policies/PolicyResult.cs
+++ b/sources/NetArchTest/Policies/PolicyResult.cs
@@ -1,9 +1,7 @@
 ﻿namespace NetArchTest.Policies
 {
-    using System;
     using System.Collections.Generic;
-    using NetArchTest.Assemblies;
-    using NetArchTest.Rules;
+    using Rules;
 
     /// <summary>
     /// A single test result for a policy.

--- a/sources/NetArchTest/Policies/PolicyResults.cs
+++ b/sources/NetArchTest/Policies/PolicyResults.cs
@@ -43,6 +43,5 @@
         /// Gets the detailed description associated with the policy.
         /// </summary>
         public string Description { get; private set; }
-
     }
 }

--- a/sources/NetArchTest/Policies/PolicyTest.cs
+++ b/sources/NetArchTest/Policies/PolicyTest.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.Policies
 {
     using System;
-    using NetArchTest.Rules;
+    using Rules;
 
     /// <summary>
     /// A single test that has been added to a policy.

--- a/sources/NetArchTest/Predicate.cs
+++ b/sources/NetArchTest/Predicate.cs
@@ -12,35 +12,31 @@ namespace NetArchTest.Rules
     /// </summary>
     public sealed partial class Predicate
     {
-        private readonly RuleContext rule;
-        private readonly PredicateContext context;
-
+        private readonly RuleContext _rule;
+        private readonly PredicateContext _context;
 
         internal Predicate(RuleContext rule)
         {
-            this.rule = rule;
-            this.context = rule.PredicateContext;
+            _rule = rule;
+            _context = rule.PredicateContext;
         }
-
 
         private PredicateList CreatePredicateList()
         {
-            return new PredicateList(rule);
+            return new PredicateList(_rule);
         }
         private void AddFunctionCall(Func<IEnumerable<TypeSpec>, IEnumerable<TypeSpec>> func)
         {
-            context.Sequence.AddFunctionCall(func);
+            _context.Sequence.AddFunctionCall(func);
         }
         private void AddFunctionCall(Func<FunctionSequenceExecutionContext, IEnumerable<TypeSpec>, IEnumerable<TypeSpec>> func)
         {
-            context.Sequence.AddFunctionCall(func);
+            _context.Sequence.AddFunctionCall(func);
         }
-
-
 
         /// <summary>
         /// Selects types that are decorated with a specific custom attribute.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveCustomAttribute(Type attribute)
         {
@@ -49,7 +45,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are decorated with a specific custom attribute.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveCustomAttribute<T>()
         {
@@ -68,7 +64,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are not decorated with a specific custom attribute.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotHaveCustomAttribute<T>()
         {
@@ -87,7 +83,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are decorated with a specific custom attribute or derived one.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveCustomAttributeOrInherit<T>()
         {
@@ -106,13 +102,12 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that are not decorated with a specific custom attribute or derived one.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotHaveCustomAttributeOrInherit<T>()
         {
             return DoNotHaveCustomAttributeOrInherit(typeof(T));
         }
-
 
         /// <summary>
         /// Selects types that inherit a particular type.
@@ -126,7 +121,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that inherit a particular type.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList Inherit<T>()
         {
@@ -135,7 +130,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are inherited by any type
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreInheritedByAnyType()
         {
@@ -145,14 +140,13 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not inherited by any type
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotInheritedByAnyType()
         {
             AddFunctionCall((context, inputTypes) => FunctionDelegates.BeInherited(context, inputTypes, false));
             return CreatePredicateList();
         }
-
 
         /// <summary>
         /// Selects types that do not inherit a particular type.
@@ -166,13 +160,12 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that do not inherit a particular type.
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotInherit<T>()
-        { 
+        {
             return DoNotInherit(typeof(T));
         }
-
 
         /// <summary>
         /// Selects types that implement a particular interface.
@@ -186,7 +179,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that implement a particular interface.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList ImplementInterface<T>()
         {
@@ -205,13 +198,12 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that do not implement a particular interface.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotImplementInterface<T>()
         {
             return DoNotImplementInterface(typeof(T));
         }
-
 
         /// <summary>
         /// Selects types that meet a custom rule.
@@ -225,7 +217,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that meet a custom rule.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public PredicateList MeetCustomRule(Func<TypeDefinition, bool> rule)
         {
@@ -245,7 +237,7 @@ namespace NetArchTest.Rules
         }
         /// <summary>
         /// Selects types that meet a custom rule.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public PredicateList MeetCustomRule(Func<TypeDefinition, CustomRuleResult> rule)
         {

--- a/sources/NetArchTest/PredicateList.cs
+++ b/sources/NetArchTest/PredicateList.cs
@@ -11,14 +11,12 @@ namespace NetArchTest.Rules
     /// </summary>
     public sealed class PredicateList
     {
-        private readonly RuleContext rule;       
+        private readonly RuleContext _rule;
 
-
-        internal PredicateList(RuleContext rule) 
+        internal PredicateList(RuleContext rule)
         {
-            this.rule = rule;          
+            _rule = rule;
         }
-
 
         /// <summary>
         /// Links a predicate defining a set of classes to a condition that tests them.
@@ -26,7 +24,7 @@ namespace NetArchTest.Rules
         /// <returns>A condition that tests classes against a given criteria.</returns>
         public Condition Should()
         {
-            return new Condition(rule, true);
+            return new Condition(_rule, true);
         }
 
         /// <summary>
@@ -35,7 +33,7 @@ namespace NetArchTest.Rules
         /// <returns>A condition that tests classes against a given criteria.</returns>
         public Condition ShouldNot()
         {
-            return new Condition(rule, false);
+            return new Condition(_rule, false);
         }
 
         /// <summary>
@@ -44,9 +42,8 @@ namespace NetArchTest.Rules
         /// <returns></returns>
         public SlicePredicate Slice()
         {
-            return new SlicePredicate(rule);
+            return new SlicePredicate(_rule);
         }
-
 
         /// <summary>
         /// Specifies that any subsequent predicates should be treated as "and" conditions.
@@ -55,7 +52,7 @@ namespace NetArchTest.Rules
         /// <remarks>And() has higher priority than Or() and it is computed first.</remarks>
         public Predicate And()
         {
-            return new Predicate(rule);
+            return new Predicate(_rule);
         }
 
         /// <summary>
@@ -65,8 +62,8 @@ namespace NetArchTest.Rules
         public Predicate Or()
         {
             // Create a new group of functions - this has the effect of creating an "or" condition
-            rule.PredicateContext.Sequence.CreateGroup();
-            return new Predicate(rule);
+            _rule.PredicateContext.Sequence.CreateGroup();
+            return new Predicate(_rule);
         }
 
         /// <summary>
@@ -75,17 +72,16 @@ namespace NetArchTest.Rules
         /// <returns>A list of types.</returns>
         public IEnumerable<IType> GetTypes(Options options = null)
         {
-            return rule.GetTypes(options);
+            return _rule.GetTypes(options);
         }
 
-
         internal IEnumerable<TypeSpec> GetTypeSpecifications(Options options = null)
-        { 
-            return rule.Execute(options);
+        {
+            return _rule.Execute(options);
         }
         internal IEnumerable<Type> GetReflectionTypes(Options options = null)
         {
-            return rule.GetReflectionTypes(options);
+            return _rule.GetReflectionTypes(options);
         }
     }
 }

--- a/sources/NetArchTest/Predicate_AccessModifiers.cs
+++ b/sources/NetArchTest/Predicate_AccessModifiers.cs
@@ -17,7 +17,7 @@ namespace NetArchTest.Rules
         /// <summary>
         /// Selects types that are not declared as internal.
         /// </summary>
-        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>       
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotInternal()
         {
             AddFunctionCall(x => FunctionDelegates.BeInternal(x, false));
@@ -57,7 +57,7 @@ namespace NetArchTest.Rules
         /// <summary>
         /// Selects types that are not declared as private.
         /// </summary>
-        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>     
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotPrivate()
         {
             AddFunctionCall(x => FunctionDelegates.BePrivate(x, false));
@@ -66,7 +66,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are declared as private protected.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList ArePrivateProtected()
         {
@@ -76,7 +76,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not declared as private protected.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotPrivateProtected()
         {
@@ -86,7 +86,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are declared as protected.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreProtected()
         {
@@ -96,7 +96,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not declared as protected.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotProtected()
         {
@@ -106,7 +106,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are declared as protected internal.
-        /// </summary>     
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreProtectedInternal()
         {
@@ -116,7 +116,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not declared as protected internal.
-        /// </summary>      
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotProtectedInternal()
         {
@@ -126,7 +126,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that have public scope.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList ArePublic()
         {
@@ -136,7 +136,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that do not have public scope.
-        /// </summary>        
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotPublic()
         {

--- a/sources/NetArchTest/Predicate_Dependencies.cs
+++ b/sources/NetArchTest/Predicate_Dependencies.cs
@@ -27,7 +27,7 @@ namespace NetArchTest.Rules
         }
 
         /// <summary>
-        /// Selects types that have a dependency on any of the supplied types and cannot have any other dependency. 
+        /// Selects types that have a dependency on any of the supplied types and cannot have any other dependency.
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
@@ -64,7 +64,7 @@ namespace NetArchTest.Rules
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public PredicateList HaveDependencyOtherThan(params string[] dependencies)  
+        public PredicateList HaveDependencyOtherThan(params string[] dependencies)
         {
             AddFunctionCall((context, inputTypes) => FunctionDelegates.OnlyHaveDependenciesOnAnyOrNone(context, inputTypes, dependencies, false));
             return CreatePredicateList();

--- a/sources/NetArchTest/Predicate_Metrics.cs
+++ b/sources/NetArchTest/Predicate_Metrics.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NetArchTest.Functions;
+﻿using NetArchTest.Functions;
 
 namespace NetArchTest.Rules
 {
@@ -25,6 +22,6 @@ namespace NetArchTest.Rules
         {
             AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNumberOfLinesOfCodeFewerThan(context, inputTypes, number, true));
             return CreatePredicateList();
-        }       
+        }
     }
 }

--- a/sources/NetArchTest/Predicate_Names.cs
+++ b/sources/NetArchTest/Predicate_Names.cs
@@ -7,7 +7,7 @@ namespace NetArchTest.Rules
     {
         /// <summary>
         /// Selects types that are exactly of given type. (inheritance is not considered)
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreOfType(params Type[] type)
         {
@@ -17,7 +17,7 @@ namespace NetArchTest.Rules
 
         /// <summary>
         /// Selects types that are not exactly of given type. (inheritance is not considered)
-        /// </summary>       
+        /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreNotOfType(params Type[] type)
         {
@@ -33,8 +33,8 @@ namespace NetArchTest.Rules
         /// </remarks>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveName(params string[] name)
-        {            
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, name, true));            
+        {
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, name, true));
             return CreatePredicateList();
         }
 
@@ -47,7 +47,7 @@ namespace NetArchTest.Rules
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotHaveName(params string[] name)
         {
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, name, false));            
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveName(context, inputTypes, name, false));
             return CreatePredicateList();
         }
 
@@ -81,8 +81,8 @@ namespace NetArchTest.Rules
         /// </remarks>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveNameStartingWith(params string[] start)
-        {           
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, start, true));            
+        {
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, start, true));
             return CreatePredicateList();
         }
 
@@ -94,8 +94,8 @@ namespace NetArchTest.Rules
         /// </remarks>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotHaveNameStartingWith(params string[] start)
-        {            
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, start, false));            
+        {
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameStartingWith(context, inputTypes, start, false));
             return CreatePredicateList();
         }
 
@@ -107,8 +107,8 @@ namespace NetArchTest.Rules
         /// </remarks>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList HaveNameEndingWith(params string[] end)
-        {            
-            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, end, true));            
+        {
+            AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, end, true));
             return CreatePredicateList();
         }
 
@@ -120,11 +120,10 @@ namespace NetArchTest.Rules
         /// </remarks>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList DoNotHaveNameEndingWith(params string[] end)
-        {          
+        {
             AddFunctionCall((context, inputTypes) => FunctionDelegates.HaveNameEndingWith(context, inputTypes, end, false));
             return CreatePredicateList();
         }
-               
 
         /// <summary>
         /// Selects types that reside in a particular namespace.

--- a/sources/NetArchTest/Predicate_Special.cs
+++ b/sources/NetArchTest/Predicate_Special.cs
@@ -62,7 +62,7 @@ namespace NetArchTest.Rules
         {
             AddFunctionCall(x => FunctionDelegates.OnlyHaveNullableMembers(x, true));
             return CreatePredicateList();
-        }  
+        }
 
         /// <summary>
         /// Selects types that have some non-nullable members.
@@ -84,7 +84,6 @@ namespace NetArchTest.Rules
             return CreatePredicateList();
         }
 
-
         /// <summary>
         /// Selects types that have at least one instance public constructor.
         /// </summary>
@@ -104,7 +103,6 @@ namespace NetArchTest.Rules
             AddFunctionCall((context, inputTypes) => FunctionDelegates.HavePublicConstructor(context, inputTypes, false));
             return CreatePredicateList();
         }
-
 
         /// <summary>
         /// Selects types that have at least one instance parameterless constructor.

--- a/sources/NetArchTest/RuleEngine/ConditionContext.cs
+++ b/sources/NetArchTest/RuleEngine/ConditionContext.cs
@@ -1,13 +1,12 @@
 ﻿namespace NetArchTest.RuleEngine
 {
     internal class ConditionContext
-    {       
+    {
         public FunctionSequence Sequence { get; } = new FunctionSequence();
         public bool Should { get; set; }
 
         public ConditionContext()
-        {            
-            
+        {
         }
     }
 }

--- a/sources/NetArchTest/RuleEngine/FunctionSequenceExecutionContext.cs
+++ b/sources/NetArchTest/RuleEngine/FunctionSequenceExecutionContext.cs
@@ -11,12 +11,11 @@ namespace NetArchTest.RuleEngine
         public IDependencyFilter DependencyFilter { get; }
         public Options UserOptions { get; }
 
-
         public FunctionSequenceExecutionContext(IEnumerable<TypeSpec> allTypes, bool isFailPathRun, Options options = null)
         {
             AllTypes = allTypes;
-            UserOptions = options ?? Options.Default; 
-            IsFailPathRun = isFailPathRun;            
+            UserOptions = options ?? Options.Default;
+            IsFailPathRun = isFailPathRun;
         }
     }
 }

--- a/sources/NetArchTest/RuleEngine/PredicateContext.cs
+++ b/sources/NetArchTest/RuleEngine/PredicateContext.cs
@@ -4,10 +4,8 @@
     {
         public FunctionSequence Sequence { get; } = new FunctionSequence();
 
-
         public PredicateContext()
         {
-           
         }
     }
 }

--- a/sources/NetArchTest/RuleEngine/RuleContext.cs
+++ b/sources/NetArchTest/RuleEngine/RuleContext.cs
@@ -9,22 +9,20 @@ namespace NetArchTest.RuleEngine
 {
     internal class RuleContext
     {
-        internal readonly LoadedData loadedData;
+        internal readonly LoadedData LoadedData;
         public PredicateContext PredicateContext { get; } = new PredicateContext();
         public ConditionContext ConditionContext { get; } = new ConditionContext();
 
-
         public RuleContext(LoadedData loadedData)
         {
-            this.loadedData = loadedData;
-        }   
-
+            LoadedData = loadedData;
+        }
 
         public IReadOnlyList<TypeSpec> Execute(Options options)
         {
-            var lodedTypes = loadedData.GetTypes().ToArray();           
+            var lodedTypes = LoadedData.GetTypes().ToArray();
             var selectedTypes = PredicateContext.Sequence.Execute(lodedTypes, options, lodedTypes);
-            var passingTypes = ConditionContext.Sequence.Execute(selectedTypes, options, lodedTypes); 
+            var passingTypes = ConditionContext.Sequence.Execute(selectedTypes, options, lodedTypes);
             return passingTypes;
         }
 
@@ -32,7 +30,7 @@ namespace NetArchTest.RuleEngine
         {
             bool success;
 
-            var lodedTypes = loadedData.GetTypes().ToArray();
+            var lodedTypes = LoadedData.GetTypes().ToArray();
             var selectedTypes = PredicateContext.Sequence.Execute(lodedTypes, options, lodedTypes);
             var passingTypes = ConditionContext.Sequence.Execute(selectedTypes, options, lodedTypes);
 
@@ -49,14 +47,13 @@ namespace NetArchTest.RuleEngine
 
             if (success)
             {
-                return new TestResult(loadedData.Assemblies, lodedTypes, selectedTypes, Array.Empty<TypeSpec>(), true);
+                return new TestResult(LoadedData.Assemblies, lodedTypes, selectedTypes, [], true);
             }
 
             // If we've failed, get a collection of failing types so these can be reported in a failing test.
             var failedTypes = ConditionContext.Sequence.ExecuteToGetFailingTypes(selectedTypes, selected: !ConditionContext.Should, options, lodedTypes);
-            return new TestResult(loadedData.Assemblies, lodedTypes, selectedTypes, failedTypes, false);
+            return new TestResult(LoadedData.Assemblies, lodedTypes, selectedTypes, failedTypes, false);
         }
-
 
         public IEnumerable<IType> GetTypes(Options options)
         {

--- a/sources/NetArchTest/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
+++ b/sources/NetArchTest/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
@@ -23,7 +23,7 @@ namespace NetArchTest.Slices.Model
                 foreach (var type in slice.Types)
                 {
                     bool isPassing = lookup.Contains(type);
-                    var typeResult = new TypeTestResult(type, isPassing);                    
+                    var typeResult = new TypeTestResult(type, isPassing);
                     result.Add(typeResult);
                 }
             }

--- a/sources/NetArchTest/Slices/Model/Slice.cs
+++ b/sources/NetArchTest/Slices/Model/Slice.cs
@@ -8,7 +8,6 @@ namespace NetArchTest.Slices.Model
         public string Name { get;  }
         public IEnumerable<TypeSpec> Types { get;  }
 
-
         public Slice(string sliceName, List<TypeSpec> types)
         {
             Name = sliceName;

--- a/sources/NetArchTest/Slices/Model/SliceContext.cs
+++ b/sources/NetArchTest/Slices/Model/SliceContext.cs
@@ -5,25 +5,23 @@ namespace NetArchTest.Slices.Model
 {
     internal class SliceContext
     {
-        private readonly LoadedData loadedData;
-        private readonly SlicedTypes slicedTypes;
+        private readonly LoadedData _loadedData;
+        private readonly SlicedTypes _slicedTypes;
 
         public SliceContext(LoadedData loadedData, SlicedTypes slicedTypes)
         {
-            this.loadedData = loadedData;
-            this.slicedTypes = slicedTypes;
+            _loadedData = loadedData;
+            _slicedTypes = slicedTypes;
         }
-
-
 
         public IReadOnlyList<AssemblySpec> GetAssemblies()
         {
-            return loadedData.Assemblies;
+            return _loadedData.Assemblies;
         }
 
         public SlicedTypes GetTypes()
         {
-            return slicedTypes;
+            return _slicedTypes;
         }
     }
 }

--- a/sources/NetArchTest/Slices/Model/SlicedTypes.cs
+++ b/sources/NetArchTest/Slices/Model/SlicedTypes.cs
@@ -4,9 +4,8 @@ namespace NetArchTest.Slices.Model
 {
     internal sealed class SlicedTypes
     {
-        public int TypeCount { get; }       
+        public int TypeCount { get; }
         public IReadOnlyList<Slice> Slices { get; }
-
 
         public SlicedTypes(int typeCount, List<Slice> slices)
         {

--- a/sources/NetArchTest/Slices/Model/Slicer.cs
+++ b/sources/NetArchTest/Slices/Model/Slicer.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Mono.Cecil;
 using NetArchTest.Assemblies;
 
-
 namespace NetArchTest.Slices.Model
 {
     internal sealed class Slicer
@@ -30,9 +29,8 @@ namespace NetArchTest.Slices.Model
                 {
                     ++typeCount;
                     int nextDotIndex = typeNamespace.IndexOf('.', prefixWithDot.Length);
-                    int startIndex = prefixWithDot.Length;
                     int endIndex = nextDotIndex > -1 ? nextDotIndex : typeNamespace.Length;
-                    string sliceName = typeNamespace.Substring(0, endIndex);                                     
+                    string sliceName = typeNamespace.Substring(0, endIndex);
 
                     if (groupedTypes.TryGetValue(sliceName, out var list))
                     {
@@ -40,7 +38,7 @@ namespace NetArchTest.Slices.Model
                     }
                     else
                     {
-                        groupedTypes[sliceName] = new List<TypeSpec>() { type };
+                        groupedTypes[sliceName] = [type];
                     }
                 }
             }

--- a/sources/NetArchTest/Slices/Model/TypeTestResult.cs
+++ b/sources/NetArchTest/Slices/Model/TypeTestResult.cs
@@ -2,16 +2,15 @@
 
 namespace NetArchTest.Slices.Model
 {
-    internal sealed class TypeTestResult 
-    { 
+    internal sealed class TypeTestResult
+    {
         public TypeSpec TypeSpec { get; }
-        public bool IsPassing { get; }        
-
+        public bool IsPassing { get; }
 
         public TypeTestResult(TypeSpec type, bool isPassing)
         {
             TypeSpec = type;
             IsPassing = isPassing;
-        }       
+        }
     }
 }

--- a/sources/NetArchTest/Slices/SliceCondition.cs
+++ b/sources/NetArchTest/Slices/SliceCondition.cs
@@ -1,5 +1,4 @@
-﻿using NetArchTest.Assemblies;
-using NetArchTest.Slices.Model;
+﻿using NetArchTest.Slices.Model;
 
 namespace NetArchTest.Slices
 {
@@ -8,30 +7,29 @@ namespace NetArchTest.Slices
     /// </summary>
     public sealed class SliceCondition
     {
-        private readonly SliceContext sliceContext;       
-        private readonly bool should;
-
+        private readonly SliceContext _sliceContext;
+        private readonly bool _should;
 
         internal SliceCondition(SliceContext sliceContext, bool should)
         {
-            this.sliceContext = sliceContext;            
-            this.should = should;
+            _sliceContext = sliceContext;
+            _should = should;
         }
 
         /// <summary>
         /// Selects types that have some dependencies on types from other slices.
-        /// </summary>  
+        /// </summary>
         public SliceConditionList HaveDependenciesBetweenSlices()
         {
-            return new SliceConditionList(sliceContext, new HaveDependenciesBetweenSlices(), should);
+            return new SliceConditionList(_sliceContext, new HaveDependenciesBetweenSlices(), _should);
         }
 
         /// <summary>
         /// Selects types that do not have dependencies on types from other slices.
-        /// </summary>       
+        /// </summary>
         public SliceConditionList NotHaveDependenciesBetweenSlices()
         {
-            return new SliceConditionList(sliceContext, new HaveDependenciesBetweenSlices(), !should);
+            return new SliceConditionList(_sliceContext, new HaveDependenciesBetweenSlices(), !_should);
         }
     }
 }

--- a/sources/NetArchTest/Slices/SliceConditionList.cs
+++ b/sources/NetArchTest/Slices/SliceConditionList.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using NetArchTest.Assemblies;
 using NetArchTest.Rules;
 using NetArchTest.Slices.Model;
 
@@ -11,47 +10,44 @@ namespace NetArchTest.Slices
     /// </summary>
     public sealed class SliceConditionList
     {
-        private readonly SliceContext sliceContext;
-        private readonly IFilter filter;        
-        private readonly bool should;
-
+        private readonly SliceContext _sliceContext;
+        private readonly IFilter _filter;
+        private readonly bool _should;
 
         internal SliceConditionList(SliceContext sliceContext, IFilter filter, bool should)
         {
-            this.sliceContext = sliceContext;
-            this.filter = filter;            
-            this.should = should;
+            _sliceContext = sliceContext;
+            _filter = filter;
+            _should = should;
         }
-
 
         /// <summary>
         /// Returns an indication of whether all the selected types satisfy the conditions.
         /// </summary>
         /// <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
-
         public TestResult GetResult()
         {
-            var slicedTypes = sliceContext.GetTypes();
+            var slicedTypes = _sliceContext.GetTypes();
 
-            var filteredTypes = filter.Execute(slicedTypes);
+            var filteredTypes = _filter.Execute(slicedTypes);
 
             if (filteredTypes.Count() != slicedTypes.TypeCount)
             {
                 throw new Exception("Filter returned wrong number of results!");
             }
 
-            bool successIsWhen = should;
+            bool successIsWhen = _should;
             bool isSuccessful = filteredTypes.All(x => x.IsPassing == successIsWhen);
 
             if (isSuccessful)
             {
                 // todo replace Array.Empty<TypeSpec>() with real data
-                return new TestResult(sliceContext.GetAssemblies(), Array.Empty<TypeSpec>(), Array.Empty<TypeSpec>(), Array.Empty<TypeSpec>(), true);
+                return new TestResult(_sliceContext.GetAssemblies(), [], [], [], true);
             }
             else
             {
                 var failingTypes = filteredTypes.Where(x => x.IsPassing == !successIsWhen);
-                return new TestResult(sliceContext.GetAssemblies(), Array.Empty<TypeSpec>(), Array.Empty<TypeSpec>(), failingTypes.Select(x => x.TypeSpec), false);
+                return new TestResult(_sliceContext.GetAssemblies(), [], [], failingTypes.Select(x => x.TypeSpec), false);
             }
         }
     }

--- a/sources/NetArchTest/Slices/SlicePredicate.cs
+++ b/sources/NetArchTest/Slices/SlicePredicate.cs
@@ -9,26 +9,24 @@ namespace NetArchTest.Slices
     /// <returns></returns>
     public sealed class SlicePredicate
     {
-        private readonly RuleContext rule;
-
+        private readonly RuleContext _rule;
 
         internal SlicePredicate(RuleContext rule)
         {
-            this.rule = rule;
+            _rule = rule;
         }
-
 
         /// <summary>
         /// Divides types into groups/slices according to the prefix pattern.
         /// It only selects types which namespaces start with a given prefix, rest of the types are ignored.
         /// Groups are defined by the first part of the namespace that comes next after prefix:
         /// namespacePrefix.(groupName).restOfNamespace
-        /// </summary>      
+        /// </summary>
         public SlicePredicateList ByNamespacePrefix(string prefix)
         {
             var slicer = new Slicer();
-            var slicedTypes = slicer.SliceByNamespacePrefix(rule.Execute(null), prefix);
-            return new SlicePredicateList(new SliceContext(rule.loadedData, slicedTypes));
+            var slicedTypes = slicer.SliceByNamespacePrefix(_rule.Execute(null), prefix);
+            return new SlicePredicateList(new SliceContext(_rule.LoadedData, slicedTypes));
         }
     }
 }

--- a/sources/NetArchTest/Slices/SlicePredicateList.cs
+++ b/sources/NetArchTest/Slices/SlicePredicateList.cs
@@ -1,5 +1,4 @@
-﻿using NetArchTest.Assemblies;
-using NetArchTest.Slices.Model;
+﻿using NetArchTest.Slices.Model;
 
 namespace NetArchTest.Slices
 {
@@ -8,21 +7,19 @@ namespace NetArchTest.Slices
     /// </summary>
     public sealed class SlicePredicateList
     {
-        private readonly SliceContext sliceContext;      
-
+        private readonly SliceContext _sliceContext;
 
         internal SlicePredicateList(SliceContext sliceContext)
         {
-            this.sliceContext = sliceContext;           
+            _sliceContext = sliceContext;
         }
-
-
+        
         /// <summary>
         /// Links a predicate defining a set of classes to a condition that tests them.
         /// </summary>
         public SliceCondition Should()
         {
-            return new SliceCondition(sliceContext, true);
+            return new SliceCondition(_sliceContext, true);
         }
 
         /// <summary>
@@ -30,13 +27,12 @@ namespace NetArchTest.Slices
         /// </summary>
         public SliceCondition ShouldNot()
         {
-            return new SliceCondition(sliceContext, false);
+            return new SliceCondition(_sliceContext, false);
         }
-
 
         internal SlicedTypes GetSlicedTypes()
         {
-            return sliceContext.GetTypes();
+            return _sliceContext.GetTypes();
         }
     }
 }

--- a/sources/NetArchTest/TestResult.cs
+++ b/sources/NetArchTest/TestResult.cs
@@ -13,46 +13,45 @@ namespace NetArchTest.Rules
     public sealed class TestResult
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Lazy<IReadOnlyList<IAssembly>> lazyLoadedAssemblies;
+        private readonly Lazy<IReadOnlyList<IAssembly>> _lazyLoadedAssemblies;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Lazy<IReadOnlyList<IType>> lazyLoadedTypes;
+        private readonly Lazy<IReadOnlyList<IType>> _lazyLoadedTypes;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Lazy<IReadOnlyList<IType>> lazySelectedTypes;
+        private readonly Lazy<IReadOnlyList<IType>> _lazySelectedTypes;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Lazy<IReadOnlyList<IType>> lazyFailingTypes;
+        private readonly Lazy<IReadOnlyList<IType>> _lazyFailingTypes;
 
         /// <summary>
         /// Gets a list of all the assemblies that were loded by <see cref="Types"/>.
-        /// </summary>   
-        public IReadOnlyList<IAssembly> LoadedAssemblies => lazyLoadedAssemblies.Value;
+        /// </summary>
+        public IReadOnlyList<IAssembly> LoadedAssemblies => _lazyLoadedAssemblies.Value;
 
         /// <summary>
         /// Gets a list of all the types that were loded by <see cref="Types"/>.
-        /// </summary>  
-        public IReadOnlyList<IType> LoadedTypes => lazyLoadedTypes.Value;
+        /// </summary>
+        public IReadOnlyList<IType> LoadedTypes => _lazyLoadedTypes.Value;
 
         /// <summary>
-        /// Gets a list of the types that passed filtering by predicates and were used as input to conditions.  
-        /// </summary>  
-        public IReadOnlyList<IType> SelectedTypesForTesting => lazySelectedTypes.Value;
+        /// Gets a list of the types that passed filtering by predicates and were used as input to conditions.
+        /// </summary>
+        public IReadOnlyList<IType> SelectedTypesForTesting => _lazySelectedTypes.Value;
 
         /// <summary>
         /// Gets a list of the types that failed the test.
-        /// </summary>              
-        public IReadOnlyList<IType> FailingTypes => lazyFailingTypes.Value;
+        /// </summary>
+        public IReadOnlyList<IType> FailingTypes => _lazyFailingTypes.Value;
 
         /// <summary>
         /// Gets a flag indicating the success or failure of the test.
         /// </summary>
         public bool IsSuccessful { get; private set; }
 
-
         internal TestResult(IEnumerable<AssemblySpec> loadedAssemblies, IEnumerable<TypeSpec> loadedTypes, IEnumerable<TypeSpec> selectedTypes, IEnumerable<TypeSpec> failingTypes, bool isSuccessful)
         {
-            lazyLoadedAssemblies = new Lazy<IReadOnlyList<IAssembly>>(() => loadedAssemblies.Select(x => x.CreateWrapper()).ToList());
-            lazyLoadedTypes = new Lazy<IReadOnlyList<IType>>(() => loadedTypes.Select(x => x.CreateWrapper()).ToList());
-            lazySelectedTypes = new Lazy<IReadOnlyList<IType>>(() => selectedTypes.Select(x => x.CreateWrapper()).ToList());
-            lazyFailingTypes = new Lazy<IReadOnlyList<IType>>(() => failingTypes.Select(x => x.CreateWrapper()).ToList());
+            _lazyLoadedAssemblies = new Lazy<IReadOnlyList<IAssembly>>(() => loadedAssemblies.Select(x => x.CreateWrapper()).ToList());
+            _lazyLoadedTypes = new Lazy<IReadOnlyList<IType>>(() => loadedTypes.Select(x => x.CreateWrapper()).ToList());
+            _lazySelectedTypes = new Lazy<IReadOnlyList<IType>>(() => selectedTypes.Select(x => x.CreateWrapper()).ToList());
+            _lazyFailingTypes = new Lazy<IReadOnlyList<IType>>(() => failingTypes.Select(x => x.CreateWrapper()).ToList());
             IsSuccessful = isSuccessful;
         }
     }

--- a/sources/NetArchTest/Types.cs
+++ b/sources/NetArchTest/Types.cs
@@ -16,22 +16,19 @@ namespace NetArchTest.Rules
     /// </summary>
     public sealed class Types
     {
-        private readonly LoadedData loadedData;
-
+        private readonly LoadedData _loadedData;
 
         private Types(LoadedData loadedData)
         {
-            this.loadedData = loadedData;
+            _loadedData = loadedData;
         }
-
-
 
         /// <summary>
         /// Creates a list of types based on all the assemblies in the current AppDomain
         /// </summary>
         /// <returns>A list of types that can have predicates and conditions applied to it.</returns>
         public static Types InCurrentDomain()
-        {            
+        {
             return new Types(DataLoader.LoadFromCurrentDomain());
         }
 
@@ -43,7 +40,7 @@ namespace NetArchTest.Rules
         /// <returns>A list of types that can have predicates and conditions applied to it.</returns>
         public static Types InAssembly(Assembly assembly, IEnumerable<string> searchDirectories = null, bool loadReferencedAssemblies = false)
         {
-            return Types.InAssemblies(new List<Assembly> { assembly }, searchDirectories, loadReferencedAssemblies);
+            return InAssemblies(new List<Assembly> { assembly }, searchDirectories, loadReferencedAssemblies);
         }
 
         /// <summary>
@@ -63,7 +60,7 @@ namespace NetArchTest.Rules
         /// <param name="fileName">The filename of the module. This is case insensitive.</param>
         /// <param name="searchDirectories">An optional list of search directories to allow resolution of referenced assemblies.</param>
         /// <remarks>Assumes that the module is in the same directory as the executing assembly.</remarks>
-        /// <returns>A list of types that can have predicates and conditions applied to it.</returns>        
+        /// <returns>A list of types that can have predicates and conditions applied to it.</returns>
         public static Types FromFile(string fileName, IEnumerable<string> searchDirectories = null)
         {
             if (string.IsNullOrEmpty(fileName))
@@ -79,7 +76,7 @@ namespace NetArchTest.Rules
                 throw new FileNotFoundException($"Could not find the assembly file {path}.");
             }
 
-            return new Types(DataLoader.LoadFromFiles(new string[] { path }, searchDirectories));           
+            return new Types(DataLoader.LoadFromFiles([path], searchDirectories));
         }
 
         /// <summary>
@@ -104,15 +101,13 @@ namespace NetArchTest.Rules
             return new Types(DataLoader.LoadFromFiles(files, searchDirectories));
         }
 
-
-
         /// <summary>
         /// Allows a list of types to be applied to one or more filters.
         /// </summary>
         /// <returns>A list of types onto which you can apply a series of filters.</returns>
         public Predicate That()
         {
-            return new Predicate(new RuleContext(loadedData));
+            return new Predicate(new RuleContext(_loadedData));
         }
 
         /// <summary>
@@ -121,7 +116,7 @@ namespace NetArchTest.Rules
         /// <returns></returns>
         public Condition Should()
         {
-            return new Condition(new RuleContext(loadedData), true);
+            return new Condition(new RuleContext(_loadedData), true);
         }
 
         /// <summary>
@@ -130,7 +125,7 @@ namespace NetArchTest.Rules
         /// <returns></returns>
         public Condition ShouldNot()
         {
-            return new Condition(new RuleContext(loadedData), false);
+            return new Condition(new RuleContext(_loadedData), false);
         }
 
         /// <summary>
@@ -139,9 +134,8 @@ namespace NetArchTest.Rules
         /// <returns></returns>
         public SlicePredicate Slice()
         {
-            return new SlicePredicate(new RuleContext(loadedData));
+            return new SlicePredicate(new RuleContext(_loadedData));
         }
-
 
         /// <summary>
         /// Returns the list of <see cref="Type"/> objects describing the types in this list.
@@ -149,7 +143,7 @@ namespace NetArchTest.Rules
         /// <returns>The list of <see cref="Type"/> objects in this list.</returns>
         public IEnumerable<IType> GetTypes(Options options = null)
         {
-            return new RuleContext(loadedData).GetTypes(options);
+            return new RuleContext(_loadedData).GetTypes(options);
         }
     }
 }

--- a/sources/NetArchTest/Utils.cs
+++ b/sources/NetArchTest/Utils.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest
 {
-    public class Utils
+    public static class Utils
     {
         public static string fullnameof<T>() => typeof(T).FullName;
         public static string namespaceof<T>() => typeof(T).Namespace;

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/DependencyLocationTests.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/DependencyLocationTests.cs
@@ -3,7 +3,7 @@
     using System;
     using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Search.DependencyLocation;
-    using NetArchTest.UnitTests.TestFixtures;
+    using TestFixtures;
     using Xunit;
 
     /// <summary>

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Search.DependencyType;
-    using NetArchTest.UnitTests.TestFixtures;
+    using TestFixtures;
     using Xunit;
     using Array = TestStructure.Dependencies.Search.DependencyType.Array;
     using Pointer = TestStructure.Dependencies.Search.DependencyType.Pointer;
@@ -303,7 +303,7 @@
         [Fact(DisplayName = "Finds a dependency ExampleDependency<int> in ExampleDependency<int>, specified as string (GenericDependency<int>)")]
         public void DependencySearch_VariableGenericAsString_Found()
         {
-            Utils.RunDependencyTest(fixture, typeof(VariableGeneric), new[] { typeof(ExampleDependency<int>).ToString() }, true);
+            Utils.RunDependencyTest(fixture, typeof(VariableGeneric), [typeof(ExampleDependency<int>).ToString()], true);
         }
 
         [Fact(DisplayName = "Does not find dependency ExampleDependency<string> in ExampleDependency<int>.")]

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/ScalabilityTests.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/ScalabilityTests.cs
@@ -1,9 +1,9 @@
 ﻿namespace NetArchTest.UnitTests.DependencySearch
 {
     using Mono.Cecil;
-    using NetArchTest.Assemblies;
-    using NetArchTest.Dependencies;
-    using NetArchTest.Rules;
+    using Assemblies;
+    using Dependencies;
+    using Rules;
     using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Implementation;
     using System;

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/SearchTypeTests.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/SearchTypeTests.cs
@@ -2,15 +2,15 @@
 {
     using System.Linq;
     using System.Reflection;
-    using NetArchTest.Dependencies;
-    using NetArchTest.Rules;
-    using NetArchTest.TestStructure.AccessModifiers;
+    using Dependencies;
+    using Rules;
+    using TestStructure.AccessModifiers;
     using NetArchTest.TestStructure.Dependencies.Implementation;
     using NetArchTest.TestStructure.Dependencies.TypeOfSearch;
     using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D1;
     using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D2;
     using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D3;
-    using NetArchTest.UnitTests.TestFixtures;
+    using TestFixtures;
     using Xunit;
 
     [CollectionDefinition("Dependency Search - search type tests ")]
@@ -80,7 +80,8 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatHaveDependencyOnAny(typeList, new string[] { typeof(Dependency_1).Namespace, typeof(Dependency_2).Namespace }).Where(x => x.IsPassing).ToList();
+            var result = search.FindTypesThatHaveDependencyOnAny(typeList, [typeof(Dependency_1).Namespace, typeof(Dependency_2).Namespace
+            ]).Where(x => x.IsPassing).ToList();
 
             // Assert           
             Assert.Equal(6, result.Count); 
@@ -105,7 +106,8 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatHaveDependencyOnAll(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName }).Where(x => x.IsPassing).ToList();
+            var result = search.FindTypesThatHaveDependencyOnAll(typeList, [typeof(Dependency_1).FullName, typeof(Dependency_2).FullName
+            ]).Where(x => x.IsPassing).ToList();
 
             // Assert           
             Assert.Equal(2, result.Count); 
@@ -126,7 +128,8 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatOnlyHaveDependencyOnAnyOrNone(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System" }).Where(x => x.IsPassing).ToList();
+            var result = search.FindTypesThatOnlyHaveDependencyOnAnyOrNone(typeList, [typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System"
+            ]).Where(x => x.IsPassing).ToList();
 
             // Assert           
             Assert.Equal(4, result.Count); 
@@ -149,7 +152,8 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatOnlyHaveDependencyOnAny(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System" }).Where(x => x.IsPassing).ToList();
+            var result = search.FindTypesThatOnlyHaveDependencyOnAny(typeList, [typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System"
+            ]).Where(x => x.IsPassing).ToList();
 
             // Assert           
             Assert.Equal(4, result.Count); 
@@ -172,7 +176,8 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatOnlyOnlyHaveDependencyOnAll(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System" }).Where(x => x.IsPassing).ToList();
+            var result = search.FindTypesThatOnlyOnlyHaveDependencyOnAll(typeList, [typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System"
+            ]).Where(x => x.IsPassing).ToList();
 
             // Assert           
             Assert.Equal(1, result.Count);
@@ -190,7 +195,7 @@
                 .GetTypeSpecifications();
 
             // Act
-            var result = search.FindTypesThatAreUsedByAny(typeList, new string[] { typeof(Class_D).FullName }, typeList).Where(x => x.IsPassing).ToList();          
+            var result = search.FindTypesThatAreUsedByAny(typeList, [typeof(Class_D).FullName], typeList).Where(x => x.IsPassing).ToList();          
 
 
             // Assert           

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/Utils/DependencySearchUtils.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/Utils/DependencySearchUtils.cs
@@ -4,10 +4,10 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using NetArchTest.Assemblies;
-    using NetArchTest.Rules;
+    using Assemblies;
+    using Rules;
     using NetArchTest.TestStructure.Dependencies.Examples;
-    using NetArchTest.UnitTests.TestFixtures;
+    using TestFixtures;
     using Xunit;
 
     internal static class Utils

--- a/tests/NetArchTest.Rules.UnitTests/DependencySearch/VariousTests.cs
+++ b/tests/NetArchTest.Rules.UnitTests/DependencySearch/VariousTests.cs
@@ -3,13 +3,13 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using NetArchTest.Rules;
+    using Rules;
     using NetArchTest.TestStructure.Dependencies.Example;
     using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Implementation;
     using NetArchTest.TestStructure.Dependencies.Search;
-    using NetArchTest.TestStructure.FalsePositives.NamespaceMatch;
-    using NetArchTest.UnitTests.TestFixtures;
+    using TestStructure.FalsePositives.NamespaceMatch;
+    using TestFixtures;
     using Xunit;
 
     [CollectionDefinition("Dependency Search - various tests")]

--- a/tests/NetArchTest.Rules.UnitTests/TestDoubles/CustomRuleExample.cs
+++ b/tests/NetArchTest.Rules.UnitTests/TestDoubles/CustomRuleExample.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.UnitTests.TestDoubles
 {
     using Mono.Cecil;
-    using NetArchTest.Rules;
+    using Rules;
     using System;
 
     /// <summary>

--- a/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasAnotherDependency.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasAnotherDependency.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Implementation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     public class HasAnotherDependency
     {

--- a/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasDependencies.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasDependencies.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Implementation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     public class HasDependencies
     {

--- a/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Implementation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     public class HasDependency
     {

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AsyncMethod.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AsyncMethod.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an asynchronous method definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnClass.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnClass.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnEvent.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnEvent.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnField.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnField.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnMethod.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnMethod.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnParameter.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnParameter.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnProperty.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnProperty.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnReturnValue.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/AttributeOnReturnValue.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as an attribute.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ConstructorPrivate.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ConstructorPrivate.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private constructor definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ConstructorPublic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ConstructorPublic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public constructor definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/DefaultInterfaceMethod.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/DefaultInterfaceMethod.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {   
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example interface that includes a dependency in default method.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/DelegateDeclaration.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/DelegateDeclaration.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example delegate that includes a dependency.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventAdd.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventAdd.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an event add accessor.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventPublic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventPublic.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public event definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventRemove.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/EventRemove.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an event add accessor.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/FieldPrivate.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/FieldPrivate.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private field definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/FieldPublic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/FieldPublic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public field definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericConstraintClass.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericConstraintClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericConstraintMethod.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericConstraintMethod.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
     using System.Collections.Generic;
 
     /// <summary>

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericMethodTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericMethodTypeArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that has dependency as second type argument on the generic method invocation type argument list   

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericMethodTypeArgumentOneOpenOneClosedTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/GenericMethodTypeArgumentOneOpenOneClosedTypeArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that has dependency as second type argument on the generic method invocation type argument list   

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedInterface.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedInterface.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
         
     /// <summary>
     /// Example class that implements dependency.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/IndexerPublic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/IndexerPublic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public indexer definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InheritedBaseClass.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InheritedBaseClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that inherits from a dependency.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionCtor.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionCtor.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionStaticClassTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionStaticClassTypeArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionStaticMethodTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionStaticMethodTypeArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionThrow.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/InstructionThrow.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/LambdaCapturedVariable.cs.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/LambdaCapturedVariable.cs.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a captured variable by lambda closure.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as a method argument.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodParameter.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodParameter.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency as a method parameter.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodPrivateBody.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodPrivateBody.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private method definition.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodReturnType.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/MethodReturnType.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in the return type of a method.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PInvoke.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PInvoke.cs
@@ -2,7 +2,7 @@
 {
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a P/Invoke.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyGetter.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyGetter.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public property definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyPrivate.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyPrivate.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private property definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyPublic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertyPublic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public property definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertySetter.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/PropertySetter.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public property definition.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/StaticLocalFunction.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/StaticLocalFunction.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a static local function body.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/SwitchPatternMatching.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/SwitchPatternMatching.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in switch pattern matching.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatch.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatch.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a catch.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatchBlock.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatchBlock.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a catch.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatchExceptionFilter.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryCatchExceptionFilter.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an exception filter.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryFinallyBlock.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/TryFinallyBlock.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a finally.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/UsingStatement.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/UsingStatement.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
 {
     using System.Collections.Generic;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in using statement.     

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/Yield.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/Yield.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a yield return statement.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Array.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Array.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an array dependency    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayJagged.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayJagged.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an array dependency    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayMultidimensional.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayMultidimensional.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an array dependency    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayOfGenerics.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayOfGenerics.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an array dependency    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayOfGenericsTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ArrayOfGenericsTypeArgument.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an array dependency    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     public class ConstStringFieldValue
     {

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterIn.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterIn.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterOut.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterOut.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterRef.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/MethodParameterRef.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in method's parameter passed by reference.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClass.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a nested class from difrent class.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassGeneric.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassGeneric.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a nested class from difrent class.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassGenericLevel2Generic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassGenericLevel2Generic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a nested class from difrent class.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassLevel2Generic.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/NestedDependencyClassLevel2Generic.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a nested class from difrent class.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Pointer.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Pointer.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in pointer declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/PointerNot.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/PointerNot.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that does not include a dependency in pointer declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/StaticGenericClass.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/StaticGenericClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Variable.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/Variable.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGeneric.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGeneric.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an instruction invocation.

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGenericTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGenericTypeArgument.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Collections.Generic;   
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.     

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGenericTypeArgumentNested.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableGenericTypeArgumentNested.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Collections.Generic;   
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.     

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRef.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRef.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRefArrayOfGenericsTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRefArrayOfGenericsTypeArgument.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRefGenericTypeArgument.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableRefGenericTypeArgument.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.    

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableTuple.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/DependencyType/VariableTuple.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;   
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes a dependency in variable declaration.     

--- a/tests/NetArchTest.TestStructure/Dependencies/Search/IndirectReference.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/Search/IndirectReference.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Examples;
 
     /// <summary>
     /// Example class that includes an indirect reference to a dependency in an different class.    

--- a/tests/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
+++ b/tests/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
@@ -4,9 +4,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
-    using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D1;
-    using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D2;
-    using NetArchTest.TestStructure.Dependencies.TypeOfSearch.D3;
+    using D1;
+    using D2;
+    using D3;
 
 #pragma warning disable 169
 

--- a/tests/NetArchTest.TestStructure/Slices/InvalidTree.cs
+++ b/tests/NetArchTest.TestStructure/Slices/InvalidTree.cs
@@ -26,7 +26,7 @@
             {
                 namespace Persistence 
                 {
-                    using NetArchTest.TestStructure.Slices.InvalidTree.FeatureB;
+                    using FeatureB;
                     using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
                     class Repository {  DAO dao; }
                 }

--- a/tests/NetArchTest.TestStructure/Slices/ValidTree.cs
+++ b/tests/NetArchTest.TestStructure/Slices/ValidTree.cs
@@ -10,10 +10,10 @@
     {
         namespace FeatureA
         {
-            using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.App;
+            using App;
             namespace App
             {
-                using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+                using Domain;
 
                 class AppService { AggregateRoot root; }
             }
@@ -26,7 +26,7 @@
             {
                 namespace Persistence 
                 {
-                    using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+                    using Domain;
                     class Repository {  AggregateRoot root; }
                 }
             }


### PR DESCRIPTION
Remove unused using directives, clean up whitespace in multiple files and rename variables and fields to .NET naming conventions. Fixed typos. Updated to C# 13.

I used R# to make these changes.